### PR TITLE
Tracking who clones the repository at Github

### DIFF
--- a/pages/Littslynn
+++ b/pages/Littslynn
@@ -1,0 +1,9 @@
+Erin Zhao
+California ／ PDT
+Mac OS X v.10.11.3
+
+Erin is a new grad student from University of Pittsburgh, majoring in Information Science. 
+Her education has provided her with a variety of information systems knowledge and practical skills; primarily in software engineering, Java development, and as well as database management. I also have proficient skills with website design, HTML, CSS, and JavaScript development, as well as website administration.
+
+Email: erinzhao959@gmail.com
+GitHub: [Littslynn](https://github.com/Littslynn)

--- a/pages/Littslynn
+++ b/pages/Littslynn
@@ -1,9 +1,0 @@
-Erin Zhao
-California ／ PDT
-Mac OS X v.10.11.3
-
-Erin is a new grad student from University of Pittsburgh, majoring in Information Science. 
-Her education has provided her with a variety of information systems knowledge and practical skills; primarily in software engineering, Java development, and as well as database management. I also have proficient skills with website design, HTML, CSS, and JavaScript development, as well as website administration.
-
-Email: erinzhao959@gmail.com
-GitHub: [Littslynn](https://github.com/Littslynn)

--- a/pages/Littslynn.md
+++ b/pages/Littslynn.md
@@ -1,0 +1,9 @@
+Erin Zhao
+California ／ PDT
+Mac OS X v.10.11.3
+
+Erin is a new grad student from University of Pittsburgh, majoring in Information Science. 
+Her education has provided her with a variety of information systems knowledge and practical skills; primarily in software engineering, Java development, and as well as database management. Her also has proficient skills with website design, HTML, CSS, and JavaScript development, as well as website administration.
+
+Email: erinzhao959@gmail.com
+Github: [Littslynn] (https://github.com/Littslynn)

--- a/pages/Littslynn.md
+++ b/pages/Littslynn.md
@@ -1,5 +1,5 @@
 Erin Zhao
-California ／ PDT
+California / PDT
 Mac OS X v.10.11.3
 
 Erin is a new grad student from University of Pittsburgh, majoring in Information Science. 


### PR DESCRIPTION
Assume the repository is private, and then it makes sense that its owner might want to track who has cloned it.

For a purely GitHub based repository, you can look at the network section in order to get an idea of who has forked your repository. Have a look at the network graph for this repository as an example:

https://github.com/cake-build/cake/network

This only gives you the most basic overview of people who have forked your repository, people who have simply cloned the repo locally won't show up on this list.