### PR TITLE
Removing unnecessary link

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -62,7 +62,6 @@ You have a couple of options.
 - [GitHub Tips](https://github.com/git-tips/tips/blob/master/README.md)
 - [Markdown Syntax](https://daringfireball.net/projects/markdown/syntax)
 - [Markdown Cheat Sheet (PDF)](https://enterprise.github.com/downloads/en/markdown-cheatsheet.pdf)
-- [Markdown Interactive Tutorial](http://www.markdowntutorial.com/lesson/1/)
 - [Vi Cheat Sheet (JPG)](https://www.shell-tips.com/sheets/vi_help_sheet.jpg)
 #### *VirtualBox*
 - [VirtualBox First Steps (Manual)](https://www.virtualbox.org/manual/ch01.html)


### PR DESCRIPTION
Refer to this [issue:](https://github.com/open-learning-exchange/open-learning-exchange.github.io/issues/497)

 This [link](http://www.markdowntutorial.com/lesson/1/) does not need to be in two different lists. It's technically listed as a[ Useful link](http://open-learning-exchange.github.io/#!pages/githubandmarkdown.md#Useful_links) but if you click on [Other helpful links and videos](http://open-learning-exchange.github.io/#!pages/faq.md#Helpful_Links) you can find it there as well.  I've checked each step and I can't seem to find any other page that does this. I don't think this is intentional.