### PR TITLE
Use SSH instead of HTTPS for Git repository as a bonus step

### DIFF
--- a/pages/gitandrepositories.md
+++ b/pages/gitandrepositories.md
@@ -16,7 +16,7 @@ As previously mentioned, you fork a repository to work on your own GitHub accoun
 ##Start here
 This is just a summary of the steps that you will need to perform. Please, keep on reading for a detailed explanation of each step.
 
-* [Clone your GitHub repository username.github.io](#Clone_your_GitHub_repository_username.github.io) 
+* [Clone your GitHub repository username.github.io](#Clone_your_GitHub_repository_username.github.io)
 * [Read the explanation to understand repositories and syncing process](#Explanation_about_repositories_and_syncing_process)   
 * [Configure a remote for your fork](#Configure_a_remote_for_your_fork)   
 * [Sync your fork](#Sync_your_fork)    
@@ -27,6 +27,9 @@ Now, we will be using GitHub repositories on a command line, which means that th
 ![GitHub Clone URL](uploads/images/githubcloneurl.png)
 
 Then, turn to your command prompt and type your repository URL in the form of `git clone https://github.com/EmilyLarkin/EmilyLarkin.io.git` into the command line. Be sure to use the correct URL to clone your repository (you will obviously type your own username).
+
+#####Clone with HTTPS or Use SSH?
+Both HTTPS and SSH URLs identify the same remote repositories but use different protocols to access the codebase. As an optional step explore the differences using [connecting-to-github-with-ssh](https://help.github.com/articles/connecting-to-github-with-ssh/).  
 
 ###Explanation about repositories and syncing process
 The previous step created a clone of your repository on your OS.


### PR DESCRIPTION
Fix for issue [502](https://github.com/open-learning-exchange/open-learning-exchange.github.io/issues/502)

Added the following text as an optional step.

##### Clone with HTTPS or Use SSH?
+ Both HTTPS and SSH URLs identify the same remote repositories but use different protocols to access the codebase. As an optional step explore the differences using [connecting-to-github-with-ssh](https://help.github.com/articles/connecting-to-github-with-ssh/).  