### PR TITLE
Change child titles to h3

### DIFF
--- a/pages/automatedtestingcodeceptjs.md
+++ b/pages/automatedtestingcodeceptjs.md
@@ -5,7 +5,7 @@ See [Documentations on Google Docs](https://docs.google.com/document/d/1FFpCPiTY
 ## Motivation
 While writing tests with the Python `unittest` library is awesome, writing tests in CodeceptJS is super simple and much more intuitive.
 
-## Code
+### Code
 
 **Python Login Example**
 ```Python
@@ -24,33 +24,33 @@ I.fillField(‘password’, password);
 I.click(‘Submit’)
 ```
 
-## Assertions
+### Assertions
 Even more importantly, while assertions in Python may sometimes be a source of confusion (we need to find the actual result we’re getting and compare it with the result we expected to see), in CodeceptJS we just use `I.see(something)` or `I.dontSee(something)` to check for the expected results.     
 Being the language much more similar to the way we would express the same requirements in English, the code is much less prone to mistakes.
 
-## Searching for Elements
+### Searching for Elements
 In Python, we need to decide whether we want to search for an element by id, by name, by css selector, or by xpath, while in CodeceptJS, we just provide an element and the element is automatically searched by id, name, css selector, and xpath, and will return an error only if the element cannot be found by any means.
 
-## Works with WebDriverIO by default (*but also with Selenium WebDriver, Protractor, and NightmareJS*)
+### Works with WebDriverIO by default (*but also with Selenium WebDriver, Protractor, and NightmareJS*)
 The instructions I provided below are setting up the environment to work with WebDriverIO, but other test runner libraries can be used as well (such as Selenium WebDriver, Protractor, and NightmareJS).
 
-## Works with Travis CI and Sauce Labs (*but also with BrowserStack and TestingBot*)
+### Works with Travis CI and Sauce Labs (*but also with BrowserStack and TestingBot*)
 Basically, CodeceptJS can work with the setup we already have in place (see [Setup Sauce Labs](http://webdriver.io/guide/services/sauce.html) for instructions on how to setup Sauce Labs).  
 However, we can also substitute Sauce Labs with BrowserStack or with TestingBot, if desired.
 
-## PageObjects and Helpers are easy to setup
+### PageObjects and Helpers are easy to setup
 [PageObjects](http://codecept.io/pageobjects/) and [Helpers](http://codecept.io/helpers/) are also very intuitive and easy to setup.
 
-## Interactive Shell
+### Interactive Shell
 CodeceptJS provides an interactive shell, that allows to insert a `pause()` call within any test, and test any instance of the `I` object interactively (i.e., on a test that fails, we may insert a `pause()` call, and then try various tests, such as `I.doubleClick(this)` or `I.click(that)`, etc. and see immediately what that command would do if it were to be included in the test).
 
-## Test call flexibility
+### Test call flexibility
 We can run all tests simply by typing `codeceptjs run` and one test only (for instance, a test called `login_test.js`) by typing `codeceptjs run . login_test.js`.   
 However, we can also run only tests that contain the word “login” by typing `codeceptjs run --grep "login"`.   
 Even more handy is the easiness with which we can run our tests on a different browser, by just typing `codeceptjs run --override '{ "helpers": {"WebDriverIO": {"browser": "chrome"}}}'`.   
 This way, instead of having to change our configuration, we can just override it momentarily.
 
-## Conclusion
+### Conclusion
 The features outlined above make of CodeceptJS an ideal environment to write tests, especially for virtual interns, who would have the opportunity to learn how to conduct automated testing, abstracting the complications derived by using a complex framework such as Selenium.  
 There would be many more reasons that may make CodeceptJS a quite attractive alternative to Python `unittest` library, not last the consideration of having an environment entirely based on JavaScript, instead of developing in JavaScript and testing in Python.  
 In conclusion, CodeceptJS deserves a more complete and thorough evaluation, since its introduction in the workflow may be considered an advantage in term of easiness of adoption and shorter developing times.
@@ -58,29 +58,29 @@ In conclusion, CodeceptJS deserves a more complete and thorough evaluation, sinc
 
 ## Setting Up a Testing Development Environment
 
-## Install Visual Studio Code
+### Install Visual Studio Code
 (This is not mandatory, but will make writing your code much easier and faster - if you are used to another text editor, that would be fine as well).  
 Go to https://code.visualstudio.com/ and install the appropriate version for your OS.
 
-## Install Node JS
+### Install Node JS
 Go to https://nodejs.org/en/ and install the appropriate version for your OS.
 
-## Install Geckodriver
+### Install Geckodriver
 Go to https://github.com/mozilla/geckodriver/releases and install the appropriate version for your OS.  
 Extract geckodriver and add it to the path.
 
-## Install Selenium Server
+### Install Selenium Server
 Download version 3.0.1 from http://www.seleniumhq.org/download/.  
 On the command line, type `java -jar selenium-server-standalone-3.0.1.jar` to start the server.
 
-## Install CodeceptJS
+### Install CodeceptJS
 On the command line, type `npm install -g codeceptjs` or, if needed, `sudo npm install -g codecept.js`
 
 Fork the new repo from https://github.com/aberdean-ole-vi/BeLL-Apps and clone it on your computer (this is temporary, until you troubleshoot the challenges outlined at the end of the file, then the tests can be merged into `ole-vi/BeLL-Apps`).
 
 Go in the tests folder within your repo: `cd BeLL-Apps/tests`
 
-## Initialize CodeceptJS
+### Initialize CodeceptJS
 On the command line, type `codeceptjs init`.  
 Follow the configuration steps,   
 
@@ -97,7 +97,7 @@ Follow the configuration steps,
 At this point, you’ll see a confirmation message listing all the files that were created, and telling you how to create your first test.  
 More importantly, though, you will see `Please install dependent packages globally: [sudo]` - type `sudo npm install -g webdriverio`  
 
-## Create new test
+### Create new test
 Type `codeceptjs gt`  
 
 - You will see `Creating a new test…` - type the name of the test you want to create and press `Enter`  
@@ -121,3 +121,4 @@ Awesome!
 While CodeceptJS works awesomely for most websites, it presents some problems to work with BeLL-Apps.   
 Specifically, when trying to load the homepage, the Selenium Server throws an error stating that jQuery is not loaded, and then it goes on throwing many more errors stating `ReferenceError: $ is not defined`.  
 Most likely, this depends on the BeLL-Apps codebase and it is not related to CodeceptJS, so it would probably be worth investigating further to find out the root cause of the error.
+

--- a/pages/automatedtestingpython.md
+++ b/pages/automatedtestingpython.md
@@ -30,7 +30,7 @@ This, however, does not seem an ideal solution, since what works locally does no
 Perhaps, setting up individual accounts on Sauce Labs to perform testing on everyone’s personal repo before opening a pull request may be a better solution, in terms of development time.
 
 ## Windows - Installing Testing Development Environment
-## Installing Nation
+### Installing Nation
 
 We assume that we already have Chocolatey (not mandatory), Vagrant, Git, Firefox, and VirtualBox installed.
 
@@ -41,7 +41,7 @@ Open git bash and type,
 
 Then, check in a browser if http://localhost:8081 is resolving to http://localhost:5981/apps/_design/bell/MyApp/index.html#login.
 
-## Installing Python, Pip, Selenium, Geckodriver, and Firefox
+### Installing Python, Pip, Selenium, Geckodriver, and Firefox
 
 1. Install python 3.5 (**open a cmd as administrator** and type `choco install python`  or download from https://www.python.org/downloads/release/python-352/)
 2. Restart the cmd window
@@ -71,10 +71,10 @@ Finally:
 13. `python test_login.py`
 
 ## MacOS/Ubuntu - Installing Testing Development Environment
-## Installing Nation
+### Installing Nation
 WIP - Needs some love.
 
-## Installing Python, Pip, Selenium, Geckodriver, and Firefox
+### Installing Python, Pip, Selenium, Geckodriver, and Firefox
 WIP - Needs some love.
 
 ## Daily Workflow (waffle.io tutorial)
@@ -145,7 +145,7 @@ class ClassName(BaseCase): // don’t forget “BaseCase”
 The test functions are getting executed in alphabetical order.  
 For example, if you you have `def test_login_logout(self)` and `def test_incorrect_username(self)`, then `def test_incorrect_username(self)` will be executed first.
 
-## Test results explained
+### Test results explained
 
 After you run a test, you may get any of the following results,
 - `E` means you have an error
@@ -160,18 +160,18 @@ It turns out that expected failure can be a confusing feature, so perhaps it’s
 
 ## Python Style Guidelines
 
-## File and Class names
+### File and Class names
 The name of each file should reflect the name of the class it contains, but it must always start by `test_` (i.e. if the class is `LoginTest`, the name of the file will be `test_login.py`).  
 This is particularly important for automatic test discovery!  
 Remember to add the `BaseCase` argument to every class (e.g., `LoginTest(BaseCase)`).
 
-## Test cases
+### Test cases
 Every test case should be named `test_` + name of test (e.g., `test_login`).  
 This is particularly important, because only methods that start with `test_`
 will be run.  
 Usually, the main method of each class should reflect the class and the file name (e.g., if you have a file named `test_login.py`, the class would be `LoginTest` and the main method should preferably be `test_login`).
 
-## Random rules
+### Random rules
 Avoid redundancy! This is true not only for Python, but also in general, and it is known as the DRY (Don’t Repeat Yourself) principle.  
 If you find yourself typing the same thing over and over again, then you should use a helper function to avoid the repetitions.
 
@@ -191,7 +191,7 @@ return x == 2
 
 WIP (Needs more love!)
 
-## QuantifiedCode
+### QuantifiedCode
 QuantifiedCode has been added to the repo to check for Python style, errors, etc.  
 You can find the QuantifiedCode check right along the usual Travis CI check.  
 QuantifiedCode will warn about stylistic problems and errors, and will also indicate clearly how to fix them.  
@@ -212,3 +212,4 @@ logs the user in
 `bell.logout(driver)` - provided a driver, logs the user out
 
 WIP - needs more love (and especially more functions!!!)
+


### PR DESCRIPTION
Some titles are childs of high level titles. I changed their markdown header format from h2 `##` to h3 `###`.
Preview the result: [automatedtestingpython.md](http://rawgit.com/tianhaopx/tianhaopx.github.io/pytest-header/#!pages/automatedtestingpython.md), [automatedtestingcodeceptjs.md](http://rawgit.com/tianhaopx/tianhaopx.github.io/pytest-header/#!pages/automatedtestingcodeceptjs.md).

Reference: [PoC Result](https://docs.google.com/document/d/1FFpCPiTY3VmFtMHmYe78jOzpHLY_6ulhfdxJd6v7jXg/edit)