### PR TITLE
Possible fix for not being able to run vagrant up under OSX

### DIFF
--- a/pages/vagrant.md
+++ b/pages/vagrant.md
@@ -81,7 +81,7 @@ or not commonly used. To see all subcommands, run the command
 ## Troubleshooting
 When typing the command "vagrant up" in OSX, you may experience an error such as the following: "vi: Box 'ole/jessie64' could not be found. Attempting to find and install...". A simple solution is to perform the command below. ```sudo rm /opt/vagrant/embedded/bin/curl``` This will remove the old version of curl and vagrant should now work as usual.
 
-For more information go here: (http://stackoverflow.com/questions/23874260/error-when-trying-vagrant-up)
+For more information go [here](http://stackoverflow.com/questions/23874260/error-when-trying-vagrant-up)
 
 
 ## Useful  Links
@@ -94,4 +94,4 @@ Instructions to enable virtualization [MAC](http://kb.parallels.com/en/5653) | [
 [Other helpful links and videos](faq.md#Helpful_Links)
 
    
-####Return to [First Steps](firststeps.md)
+#### Return to [First Steps](firststeps.md)

--- a/pages/vagrant.md
+++ b/pages/vagrant.md
@@ -77,6 +77,13 @@ Additional subcommands are available, but are either more advanced
 or not commonly used. To see all subcommands, run the command
 `vagrant list-commands`.
 ```
+
+## Troubleshooting
+When typing the command "vagrant up" in OSX, you may experience an error such as the following: "vi: Box 'ole/jessie64' could not be found. Attempting to find and install...". A simple solution is to perform the command below. ```sudo rm /opt/vagrant/embedded/bin/curl``` This will remove the old version of curl and vagrant should now work as usual.
+
+For more information go here: (http://stackoverflow.com/questions/23874260/error-when-trying-vagrant-up)
+
+
 ## Useful  Links
 
 Instructions to enable virtualization [MAC](http://kb.parallels.com/en/5653) | [Ubuntu](http://askubuntu.com/questions/256792/how-do-i-enable-hardware-virtualization-technology-vt-x-for-use-in-virtualbox)  


### PR DESCRIPTION
Added a suggestion for users experiencing the error "vi: Box 'ole/jessie64' could not be found. Attempting to find and install...". If the answer is on the page somewhere, users may less likely be deterred from installing Vagrant, saving the user time. I put all of this under a troubleshooting section near the end of document.

Update by @mappuji :
Rawgit [here](https://rawgit.com/snazzybunny/snazzybunny.github.io/snazzybunny-patch-1/index.html#!pages/vagrant.md)
