### PR TITLE
Adding Summary/Synopsis section to FAQ (Solution to Issue #761)

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -113,6 +113,17 @@ git clone https://github.com/dogi/ole--vagrant-vi.git
 cd ole--vagrant-vi
 vagrant up
 ```
+# 'First Steps' Software Summary
+
+###### _The aim of the ‘First Steps’ is to introduce prospective interns to the software that they will be using, and make sure they are familiar with each. While each step goes into detail on the specific program(s) at hand, it can be easy at times to lose sight of the bigger picture. To that end, below is a brief synopsis of the primary tools you will be using/learning about in the first steps, and how they work together to empower our collaborative development environment._
+
+We start off by learning about “BeLL”, or the Basic e-Learning Library. BeLL is the learning tool that OLE uses to provide the educational materials and resources to its students. It is a lightweight digital Library that can be accessed through Local networks (’Communities’)  and synced through the Internet (‘Nations’). To do so, we need to install a few software packages, Vagrant and VirtualBox primary among them. We use Vagrant (a development environment builder), in conjunction with VirtualBox (virtual machine software) to initialize a BeLL environment on the local system. Using this virtual environment we access the BeLL interface locally and create our own communities/nations.
+
+The other two tools we focus on are GitHub and Markdown. Similar to how we use Vagrant and VirtualBox to standardize the development environment for each developer, we use Git/GitHub in order to centralize the development process, and enable greater collaboration and teamwork. Git is a revision control system that allows many users to simultaneously edit and develop the same projects, and GitHub is a website/hosting service that utilizes the git system, and hosts the git repositories we work on. Markdown, on the other hand, is a style of formatting text native to GitHub and thus used in the Virtual Intern program. Markdown simplifies formatting and emphasizes readability, helping coders focus on content, and not get bogged down in syntax.
+
+To sum up, the primary software/tools we cover in the ‘First Steps’ are BeLL, Vagrant, VirtualBox, Git/GitHub and Markdown. Though not immediately apparent, the tools we use are all unified by a common purpose. Each bit of software we use is chosen in an effort to promote collaboration. The use of Vagrant and VirtualBox mandates that each instance of BeLL is the same, making sure that all developers utilize the same system. Markdown simplifies the development process, as each piece of code must comply to its syntax, increasing clarity for all users. Finally, GitHub serves as the last piece in the puzzle, as it takes advantage of the standardized development environment that Vagrant/VirtualBox provide, as well as the streamlined syntax of Markdown to allow for easy collaboration. 
+
+It can often be challenging to see the “Big Picture", and it’s easy to lose sight of it when focused on individual tasks. With that said, hopefully this synopsis will have shed light on the importance of the process, and shown that each step is not an isolated assignment, but rather part of a greater task.
 
 ## Helpful Links
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -113,7 +113,7 @@ git clone https://github.com/dogi/ole--vagrant-vi.git
 cd ole--vagrant-vi
 vagrant up
 ```
-# 'First Steps' Software Summary
+## 'First Steps' Software Summary
 
 ###### _The aim of the ‘First Steps’ is to introduce prospective interns to the software that they will be using, and make sure they are familiar with each. While each step goes into detail on the specific program(s) at hand, it can be easy at times to lose sight of the bigger picture. To that end, below is a brief synopsis of the primary tools you will be using/learning about in the first steps, and how they work together to empower our collaborative development environment._
 

--- a/pages/profiles/aurinsomnia.md
+++ b/pages/profiles/aurinsomnia.md
@@ -23,11 +23,12 @@ I've done some minor web development work, but nothing to the extent of the work
 so I'm really looking forward to the opportunity of learning and working on a project of this scale. 
 
 #### Outside of Coding, some of my other Hobbies include: ####
-* Basketball (_Huge Celtics fan, and love playing as well_)![Isaiah Thomas <3](http://i.cdn.turner.com/drp/nba/celtics/sites/default/files/styles/story_main_photo/public/170429thomas2.jpg?itok=3UQ3hgEP)
+![Isaiah Thomas <3](http://i.cdn.turner.com/drp/nba/celtics/sites/default/files/styles/story_main_photo/public/170429thomas2.jpg?itok=3UQ3hgEP)
+* Basketball (_Huge Celtics fan, and love playing as well_)
 * Soccer
 * I used to play a ton of Video Games, but quit them in the name of productivity. Instead I discovered internet Chess and fell in love with that :/
 * Now instead of playing Video Games, I watch them, with CS:GO and Dota 2 being the primary examples (*Huge EG and Cloud9 supporter*)
 * When I'm at school I enjoy going out with friends, and having a good time
 * Lastly, I've been building desktops since I was 12, and am looking forward to building a new machine this summer (*[Ryzen's](https://www.amd.com/en/ryzen) got me really hyped...*)
 
-My primary computer is a Macbook Pro, so I mainly use Mac OS X (*10.12.4 currently*) for coding, but I also utilize [reFind](http://www.rodsbooks.com/refind/) to dual-boot an Ubuntu (_16.04_) partition as well, and I have a Windows 7 desktop at home.
+My primary computer is a Macbook Pro, so I mainly use Mac OS X (*10.12.4 currently*) for coding, but I also utilize [reFind](http://www.rodsbooks.com/refind/) to dual-boot an Ubuntu (_16.04_) partition. I also have an older Windows 7 desktop at home.

--- a/pages/profiles/aurinsomnia.md
+++ b/pages/profiles/aurinsomnia.md
@@ -3,7 +3,23 @@
 I'm from Boston, MA so based in the EST time zone of course. I am currently a sophomore at UMass Lowell, majoring in Computer Science.
 So far my courses have been primarily taught in C, but next semester we are taking the step up to C++, so I'm naturally quite excited
 for that experience. I've had experience in a few languages, but given the extent of my coursework, I am by far most adept at C, 
-but am always excited to learn more! I've done some minor web development work, but nothing to the extent of the work at OLE,
+but am always excited to learn more! 
+I've made up a chart to list some of my proficiency/familiarity levels with different languages:
+
+
+| Language      | Proficiency   |
+| ------------- |:-------------:|
+| C             | Proficient |
+| C++           | Familiar/Low Intermediate    |
+| Python        | Limited Experience     |
+| HTML          | Intermediate     |
+| CSS           | Intermediate     |
+| Javascript    | Intermediate    |
+| Bootstrap     | Beginner     |
+
+
+
+I've done some minor web development work, but nothing to the extent of the work at OLE,
 so I'm really looking forward to the opportunity of learning and working on a project of this scale. 
 
 #### Outside of Coding, some of my other Hobbies include: ####
@@ -14,4 +30,4 @@ so I'm really looking forward to the opportunity of learning and working on a pr
 * When I'm at school I enjoy going out with friends, and having a good time
 * Lastly, I've been building desktops since I was 12, and am looking forward to building a new machine this summer (*Ryzen's got me really hyped...*)
 
-I primarily use Mac OS X (*10.12.4 currently*) for coding, but I have an Ubuntu (_16.04_) partition on my laptop as well, and a Windows desktop at home.
+My primary computer is a Macbook Pro, so I mainly use Mac OS X (*10.12.4 currently*) for coding, but I also utilize [reFind](http://www.rodsbooks.com/refind/) to dual-boot an Ubuntu (_16.04_) partition as well, and I have a Windows 7 desktop at home.

--- a/pages/profiles/aurinsomnia.md
+++ b/pages/profiles/aurinsomnia.md
@@ -1,0 +1,17 @@
+*Name:* __Auris Kveraga__ (github: _aurinsomnia_)
+
+I'm from Boston, MA so based in the EST time zone of course. I am currently a sophomore at UMass Lowell, majoring in Computer Science.
+So far my courses have been primarily taught in C, but next semester we are taking the step up to C++, so I'm naturally quite excited
+for that experience. I've had experience in a few languages, but given the extent of my coursework, I am by far most adept at C, 
+but am always excited to learn more! I've done some minor web development work, but nothing to the extent of the work at OLE,
+so I'm really looking forward to the opportunity of learning and working on a project of this scale. 
+
+#### Outside of Coding, some of my other Hobbies include: ####
+* Basketball (_Huge Celtics fan, and love playing as well_)
+* Soccer
+* I used to play a ton of Video Games, but quit them in the name of productivity. Instead I discovered internet Chess and fell in love with that :/
+* Now instead of playing Video Games, I watch them, with CS:GO and Dota 2 being the primary examples (*Huge EG and Cloud9 supporter*)
+* When I'm at school I enjoy going out with friends, and having a good time
+* Lastly, I've been building desktops since I was 12, and am looking forward to building a new machine this summer (*Ryzen's got me really hyped...*)
+
+I primarily use Mac OS X (*10.12.4 currently*) for coding, but I have an Ubuntu (_16.04_) partition on my laptop as well, and a Windows desktop at home.

--- a/pages/profiles/aurinsomnia.md
+++ b/pages/profiles/aurinsomnia.md
@@ -23,11 +23,11 @@ I've done some minor web development work, but nothing to the extent of the work
 so I'm really looking forward to the opportunity of learning and working on a project of this scale. 
 
 #### Outside of Coding, some of my other Hobbies include: ####
-* Basketball (_Huge Celtics fan, and love playing as well_)
+* Basketball (_Huge Celtics fan, and love playing as well_)![Isaiah Thomas <3](http://i.cdn.turner.com/drp/nba/celtics/sites/default/files/styles/story_main_photo/public/170429thomas2.jpg?itok=3UQ3hgEP)
 * Soccer
 * I used to play a ton of Video Games, but quit them in the name of productivity. Instead I discovered internet Chess and fell in love with that :/
 * Now instead of playing Video Games, I watch them, with CS:GO and Dota 2 being the primary examples (*Huge EG and Cloud9 supporter*)
 * When I'm at school I enjoy going out with friends, and having a good time
-* Lastly, I've been building desktops since I was 12, and am looking forward to building a new machine this summer (*Ryzen's got me really hyped...*)
+* Lastly, I've been building desktops since I was 12, and am looking forward to building a new machine this summer (*[Ryzen's](https://www.amd.com/en/ryzen) got me really hyped...*)
 
 My primary computer is a Macbook Pro, so I mainly use Mac OS X (*10.12.4 currently*) for coding, but I also utilize [reFind](http://www.rodsbooks.com/refind/) to dual-boot an Ubuntu (_16.04_) partition as well, and I have a Windows 7 desktop at home.

--- a/pages/profiles/aurinsomnia.md
+++ b/pages/profiles/aurinsomnia.md
@@ -24,6 +24,7 @@ so I'm really looking forward to the opportunity of learning and working on a pr
 
 #### Outside of Coding, some of my other Hobbies include: ####
 ![Isaiah Thomas <3](http://i.cdn.turner.com/drp/nba/celtics/sites/default/files/styles/story_main_photo/public/170429thomas2.jpg?itok=3UQ3hgEP)
+
 * Basketball (_Huge Celtics fan, and love playing as well_)
 * Soccer
 * I used to play a ton of Video Games, but quit them in the name of productivity. Instead I discovered internet Chess and fell in love with that :/


### PR DESCRIPTION
As I talked about in issue #761 (Improvements in clarity in FAQ), I feel the FAQ page is currently too focused on troubleshooting, and for a new intern it can be challenging at times to understand the purpose of all the steps. To that end I have written a brief summary of the most important pieces of software we use in the first steps process, and covered why we use these programs, how they combine to help us develop, and why they are useful. I have inserted the summary section after the FAQ but before the Helpful Links. In this way it doesn't overshadow the primary goal of the page (FAQ's), but is still visible and can be of use to a potential intern looking for clarity.

Update:
Rawgit [here](https://rawgit.com/aurinsomnia/aurinsomnia.github.io/my-new-branch/index.html#!pages/faq.md)