### PR TITLE
Header fix for all headers in nation.md and removed level one block quote on line 26 solve #770

### DIFF
--- a/pages/nation.md
+++ b/pages/nation.md
@@ -23,7 +23,7 @@ Then, "Select All" and click "Send".
 You have now sent all activities on your community to the nation. To explain further, the nation receives a number of data points: number of resources opened, number of logins, number of members, resource ratings, technical feedback, and resource requests. We don't get specific information on individual users, but rather usage and feedback as whole.
 
 ##Check the Sync Worked
-> On the nation side ([vi.ole.org](http://vi.ole.org)), you can log in with the username `admin` and the password `password` and check that the sync worked. Click on "Manager" once again.
+On the nation side ([vi.ole.org](http://vi.ole.org)), you can log in with the username `admin` and the password `password` and check that the sync worked. Click on "Manager" once again.
 
 ![Clicking on "Manager" after logging in to the nation](uploads/images/nation.md4.png)
 

--- a/pages/nation.md
+++ b/pages/nation.md
@@ -1,5 +1,5 @@
-#Nation BeLL
-##Introduction
+# Nation BeLL
+## Introduction
 
 In step 4, you registered your community BeLL with the nation. Now, you will learn how to keep your community BeLL in sync with the nation.
 
@@ -7,7 +7,7 @@ There should be constant communication between the nation and the communities. W
 
 **NOTE**: After you register your community, but before you can sync with the nation, you need to create an additional dummy user on your community. Therefore, create a quick additional user under "Become a Member" on the login page (HINT: When creating the dummy user, don't give it a password that you actually use, as other people logged in as admin may be able to see it-- you won't need the password in the future so don't worry about having to remember or save it after this one time). Then, login and double-check that you're listed under Members. Then, log out and log back in with your admin account. Now that your community has a user, you can sync with the nation.
 
-##Sync With the Nation
+## Sync With the Nation
 As you can see from the picture below, click on "Manager".
 
 ![Clicking on "Manager"](uploads/images/nation.md1.png)
@@ -22,7 +22,7 @@ Then, "Select All" and click "Send".
 
 You have now sent all activities on your community to the nation. To explain further, the nation receives a number of data points: number of resources opened, number of logins, number of members, resource ratings, technical feedback, and resource requests. We don't get specific information on individual users, but rather usage and feedback as whole.
 
-##Check the Sync Worked
+## Check the Sync Worked
 On the nation side ([vi.ole.org](http://vi.ole.org)), you can log in with the username `admin` and the password `password` and check that the sync worked. Click on "Manager" once again.
 
 ![Clicking on "Manager" after logging in to the nation](uploads/images/nation.md4.png)
@@ -35,7 +35,7 @@ Then, you should see a list of communities and the option to generate a report i
 
 ![Generate Report](uploads/images/nation.md6.png)
 
-##Different Kinds of Update
+## Different Kinds of Update
 Above is the usual syncing process from the community side. There are three other important kinds of updates that you receive on the community side: updates, publications, and surveys.  
 
 As you can see from the image below, there is an update ready to be downloaded. Usually, next to the update, you should also see two publications ready to be downloaded. 
@@ -44,8 +44,8 @@ As you can see from the image below, there is an update ready to be downloaded. 
 
 First, click the "Update Available" button and it will reload your homepage with a successful update message. An update refers to a new software update which improves the software. Next, click on "Publications" and sync the publications. Publications add new resources or courses to your library. Last, repeat the process of sending an activities sync to the nation.
 
-##Useful Links
+## Useful Links
 
 [Helpful links and videos](faq.md#Helpful_Links)
 
-####Return to [First Steps](firststeps.md)
+#### Return to [First Steps](firststeps.md)


### PR DESCRIPTION
Headers in nation.md do not comply to markdown syntax. Also, removed level one block quote to just regular text (line 26) as it looks better when all instructions are the same size. Please see #770 for more details.

Update by @mappuji
Rawgit [here](https://rawgit.com/snazzybunny/snazzybunny.github.io/snazzybunny-patch-3/index.html#!pages/nation.md)