### PR TITLE
Simplifying 'First Steps' formatting by including 'Objective' section (Solution to Issue #764)

### DIFF
--- a/pages/bellapps.md
+++ b/pages/bellapps.md
@@ -1,4 +1,9 @@
 #BeLL-Apps: Communities and Nations
+##Objective
+* Learn more about the BeLL and its interface
+* Configure the BeLL Community you initialized in Step 1
+* Explore the BeLL software, upload resources, and submit your configuration to an Admin
+
 ##Introduction
 
 The BeLL (Basic e-Learning Library) is not only a library, but also an individualized learning system, where students can select their own books and courses to target their individual goals. The two kinds of BeLL apps are described below.

--- a/pages/bellapps.md
+++ b/pages/bellapps.md
@@ -1,4 +1,5 @@
 #BeLL-Apps: Communities and Nations
+
 ##Objective
 * Learn more about the BeLL and its interface
 * Configure the BeLL Community you initialized in Step 1

--- a/pages/githubissues.md
+++ b/pages/githubissues.md
@@ -1,4 +1,7 @@
 #GitHub Issues
+##Objective
+* Learn the process of submitting an issue through GitHub
+* Find and submit your own issue and pull request
 
 On GitHub, each repository has a section where issues can be added, discussed, and fixed as a means of categorizing and addressing problems we find. Issues are often opened by our team to fix software bugs on the BeLL and in our code. Below, you'll find an example of an issue where I brought up a problem, researched an answer, and then fixed the issue.
 

--- a/pages/githubissues.md
+++ b/pages/githubissues.md
@@ -4,6 +4,8 @@
 * Learn the process of submitting an issue through GitHub
 * Find and submit your own issue and pull request
 
+##Introduction
+
 On GitHub, each repository has a section where issues can be added, discussed, and fixed as a means of categorizing and addressing problems we find. Issues are often opened by our team to fix software bugs on the BeLL and in our code. Below, you'll find an example of an issue where I brought up a problem, researched an answer, and then fixed the issue.
 
 First, you will need to open an issue within the right repository ([upstream repository](https://github.com/open-learning-exchange/open-learning-exchange.github.io)) and explain the problem. If you are explaining a bug or how to replicate an issue, please be as explicit as possible and use pictures if possible.
@@ -20,10 +22,13 @@ Now you can go and make the proposed changes to your local files.
 
 **NOTE**: It's important that you are on the new branch, make sure you are on the correct branch with `git checkout branch-name` before committing. Use `git branch` to make sure you are on the correct branch.
 
-####Creating a commit
+##Create a Commit
+
 After you are done making your changes use the command `git status`. If the list of files changed only includes those you wish to modify, use the command `git add .` (The '.' is part of the command.) Otherwise you can also choose only certain changes to include by using `git add <file1> <file2> <file3>...`  Now that you have selected the files you wish to include, use the commands `git commit -m "commit message"` and `git push -u origin name_of_your_new_branch` to save your changes and push them to your Github (for any further commit on the same branch after the first one, you can just use `git push`).
 
 You can view your changes by going to <code>https://<b>rawgit.com</b>/YourUserName/YourUserName.github.io/YourBranchName/#!index.md</code> and viewing the page(s) you have changed. If everything looks correct, you are ready to create a pull request. Please remember to include the issue it is solving (for example, if your pull request fixes the issue number 320, then add `#320` to your pull request).
+
+##Wait for Review
 
 All that remains is posting your pull request in the chat and waiting until one of the OLE staff gets a chance to look at it. Be aware that a staff member may either submit a code review asking you to modify some of your changes, or accept the pull request and close the issue. You can see the process [here](https://github.com/open-learning-exchange/open-learning-exchange.github.io/issues/15).
 

--- a/pages/githubissues.md
+++ b/pages/githubissues.md
@@ -1,4 +1,5 @@
 #GitHub Issues
+
 ##Objective
 * Learn the process of submitting an issue through GitHub
 * Find and submit your own issue and pull request

--- a/pages/githubissues.md
+++ b/pages/githubissues.md
@@ -1,10 +1,10 @@
-#GitHub Issues
+# GitHub Issues
 
-##Objective
+## Objective
 * Learn the process of submitting an issue through GitHub
 * Find and submit your own issue and pull request
 
-##Introduction
+## Introduction
 
 On GitHub, each repository has a section where issues can be added, discussed, and fixed as a means of categorizing and addressing problems we find. Issues are often opened by our team to fix software bugs on the BeLL and in our code. Below, you'll find an example of an issue where I brought up a problem, researched an answer, and then fixed the issue.
 
@@ -22,13 +22,13 @@ Now you can go and make the proposed changes to your local files.
 
 **NOTE**: It's important that you are on the new branch, make sure you are on the correct branch with `git checkout branch-name` before committing. Use `git branch` to make sure you are on the correct branch.
 
-##Create a Commit
+## Create a Commit
 
 After you are done making your changes use the command `git status`. If the list of files changed only includes those you wish to modify, use the command `git add .` (The '.' is part of the command.) Otherwise you can also choose only certain changes to include by using `git add <file1> <file2> <file3>...`  Now that you have selected the files you wish to include, use the commands `git commit -m "commit message"` and `git push -u origin name_of_your_new_branch` to save your changes and push them to your Github (for any further commit on the same branch after the first one, you can just use `git push`).
 
 You can view your changes by going to <code>https://<b>rawgit.com</b>/YourUserName/YourUserName.github.io/YourBranchName/#!index.md</code> and viewing the page(s) you have changed. If everything looks correct, you are ready to create a pull request. Please remember to include the issue it is solving (for example, if your pull request fixes the issue number 320, then add `#320` to your pull request).
 
-##Wait for Review
+## Wait for Review
 
 All that remains is posting your pull request in the chat and waiting until one of the OLE staff gets a chance to look at it. Be aware that a staff member may either submit a code review asking you to modify some of your changes, or accept the pull request and close the issue. You can see the process [here](https://github.com/open-learning-exchange/open-learning-exchange.github.io/issues/15).
 

--- a/pages/githubissues.md
+++ b/pages/githubissues.md
@@ -36,8 +36,8 @@ All that remains is posting your pull request in the chat and waiting until one 
 
 **NOTE**: This is an exercise to help you familiarize with GitHub issues, committing, and creating pull requests. This is a common process in large open source projects as there is always room for improvement. So, we strongly encourage you to follow this process and continue to post issues and resolve them.
 
-##Useful Links
+## Useful Links
 [Helpful links and videos](faq.md#Helpful_Links)  
 [Mastering Issues](https://guides.github.com/features/issues/)
 
-####Return to [First Steps](firststeps.md)
+#### Return to [First Steps](firststeps.md)

--- a/pages/nation.md
+++ b/pages/nation.md
@@ -1,16 +1,18 @@
-# Nation BeLL
+#Nation BeLL
 
-## Objectives
+##Objectives
 * Sync your Community BeLL with the Nation
 * Verify its success using [vi.ole.org](vi.ole.org)
 * Update your Community and its publications
 
-## Introduction
+##Introduction
 In step 4, you registered your community BeLL with the nation. Now, you will learn how to keep your community BeLL in sync with the nation.
 
 There should be constant communication between the nation and the communities. While is not necessary for remote communities in the field, it is ideal for our goals of improving the software and testing the increasing forms of communication and feedback between the nation and the communities. This communication takes the form of a syncing process from the community side, where you select material to send to the nation.
 
 **NOTE**: After you register your community, but before you can sync with the nation, you need to create an additional dummy user on your community. Therefore, create a quick additional user under "Become a Member" on the login page (HINT: When creating the dummy user, don't give it a password that you actually use, as other people logged in as admin may be able to see it-- you won't need the password in the future so don't worry about having to remember or save it after this one time). Then, login and double-check that you're listed under Members. Then, log out and log back in with your admin account. Now that your community has a user, you can sync with the nation.
+
+##Sync with the Nation
 
 As you can see from the picture below, click on "Manager".
 
@@ -26,6 +28,8 @@ Then, "Select All" and click "Send".
 
 You have now sent all activities on your community to the nation. To explain further, the nation receives a number of data points: number of resources opened, number of logins, number of members, resource ratings, technical feedback, and resource requests. We don't get specific information on individual users, but rather usage and feedback as whole.
 
+## Check if the Sync worked
+
 > On the nation side ([vi.ole.org](http://vi.ole.org)), you can log in with the username `admin` and the password `password` and check that the sync worked. Click on "Manager" once again.
 
 ![Clicking on "Manager" after logging in to the nation](uploads/images/nation.md4.png)
@@ -37,6 +41,7 @@ Then, click on "Communities" to access reports from various communities on the n
 Then, you should see a list of communities and the option to generate a report if you so wished.
 
 ![Generate Report](uploads/images/nation.md6.png)
+## Different kinds of Updates
 
 This is the usual syncing process from the community side. There are three other important kinds of updates that you receive on the community side: updates, publications, and surveys.  
 

--- a/pages/nation.md
+++ b/pages/nation.md
@@ -1,5 +1,11 @@
-#Nation BeLL
+# Nation BeLL
 
+## Objectives
+* Sync your Community BeLL with the Nation
+* Verify its success using [vi.ole.org](vi.ole.org)
+* Update your Community and its publications
+
+## Introduction
 In step 4, you registered your community BeLL with the nation. Now, you will learn how to keep your community BeLL in sync with the nation.
 
 There should be constant communication between the nation and the communities. While is not necessary for remote communities in the field, it is ideal for our goals of improving the software and testing the increasing forms of communication and feedback between the nation and the communities. This communication takes the form of a syncing process from the community side, where you select material to send to the nation.
@@ -40,8 +46,8 @@ As you can see from the image below, there is an update ready to be downloaded. 
 
 First, click the "Update Available" button and it will reload your homepage with a successful update message. An update refers to a new software update which improves the software. Next, click on "Publications" and sync the publications. Publications add new resources or courses to your library. Last, repeat the process of sending an activities sync to the nation.
 
-##Useful Links
+## Useful Links
 
 [Helpful links and videos](faq.md#Helpful_Links)
 
-####Return to [First Steps](firststeps.md)
+#### Return to [First Steps](firststeps.md)

--- a/pages/nation.md
+++ b/pages/nation.md
@@ -6,6 +6,7 @@
 * Update your Community and its publications
 
 ##Introduction
+
 In step 4, you registered your community BeLL with the nation. Now, you will learn how to keep your community BeLL in sync with the nation.
 
 There should be constant communication between the nation and the communities. While is not necessary for remote communities in the field, it is ideal for our goals of improving the software and testing the increasing forms of communication and feedback between the nation and the communities. This communication takes the form of a syncing process from the community side, where you select material to send to the nation.

--- a/pages/vagrant.md
+++ b/pages/vagrant.md
@@ -1,8 +1,4 @@
 # Vagrant
-## Objective
-* Learn about Vagrant
-* Initialize a Community BeLL using Vagrant
-
 [Vagrant](https://www.vagrantup.com/) is an open source tool to build development environments. We assume that you have followed the first instructions on [README.md](https://github.com/dogi/ole--vagrant-vi) to install Vagrant and VirtualBox on your OS. Below, you will find a shortened version on how to install this software quickly if needed as a reference.
 
 ## Ubuntu

--- a/pages/vagrant.md
+++ b/pages/vagrant.md
@@ -1,4 +1,7 @@
 # Vagrant
+## Objective
+* Learn about Vagrant
+* Initialize a Community BeLL using Vagrant
 
 [Vagrant](https://www.vagrantup.com/) is an open source tool to build development environments. We assume that you have followed the first instructions on [README.md](https://github.com/dogi/ole--vagrant-vi) to install Vagrant and VirtualBox on your OS. Below, you will find a shortened version on how to install this software quickly if needed as a reference.
 


### PR DESCRIPTION
As I talked about in Issue #764, currently the "First Steps" pages do not have a unified format. While some pages such as the Vagrant guides are more quick tutorials than anything else, sections/steps wherein the user must follow detailed procedures and accomplish tasks don't necessarily make it clear what exactly must be accomplished. Many of the steps have a myriad of different tasks to complete, but they are each hidden in a brief sentence and easily missed. As I covered in the Issue, adding a clear Objective tab at the top of each respective step that is currently missing it (In this case steps 4, 6, and 7) would add a great deal of clarity and focus to the task. With that goal in mind, I have altered the bellapps.md, githubissues.md, and nation.md files in order to add this new formatting.