### PR TITLE
Add an alternative option to install setuptools for issue #778

### DIFF
--- a/pages/htmlresources.md
+++ b/pages/htmlresources.md
@@ -39,6 +39,10 @@ The following command should take care of this:
 
 `> curl https://bootstrap.pypa.io/ez_setup.py -o - | python`
 
+An alternative option is to use `pip` instead:
+ 
+`> pip install setuptools`
+
 #### Windows
 There are two possible methods for installing python, method 1 requires you to install python and other prerequisites. Method 2 is a standalone .exe file.
 


### PR DESCRIPTION
Hi @mappuji, I added the alternative option. Here is my [rawgit](https://rawgit.com/duongdo27/open-learning-duongdo.github.io/fix_deprecated_setuptools_install/#!./pages/htmlresources.md#Couchapp_Installation). 