### PR TITLE
Header fixes for "planetusermanual.md" and "takehome.md" (Solution to Issue #770)

### DIFF
--- a/pages/planetusermanual.md
+++ b/pages/planetusermanual.md
@@ -46,7 +46,7 @@ The **nations** may store thousands of Resources in many formats and languages. 
 
 NOTE: Each PLANET system is unique; universal memberships do not exist.  If you become a member of a specific Nation or Community, you do not automatically become a member of any other existing Nations and Community.  To become a member of another Nation or Community you must register with a new account.
 
-###_What are the differences between Learners, Leaders, and Managers?_
+### _What are the differences between Learners, Leaders, and Managers?_
 In the PLANET system, there are three different kinds of users: **Learners**, **Leaders**, and **Managers**.
 
 **Learner** is the default user level when a person first joins. Each person continues to be a Learner regardless of additional responsibilities and roles. All Learners have access to standard and individualized user functionality.
@@ -56,7 +56,7 @@ In the PLANET system, there are three different kinds of users: **Learners**, **
 **Managers** have access to Learner, Leader, and additional functionalities that allow them to manage local Resources, publications, collections, surveys, data sync schedules, and local software updates.  
 If you are currently using this manual, then you are most likely a manager who is organizing and overseeing a Community or a Nation and its Communities.  In order to see the available manager functionalities, click on “_Manager_” next to your name on the Dashboard (see below, _How do I navigate the Dashboard_). Managers can also add, hide, delete, and view the details of Resources as well they can create, edit, re-categorize, and delete collections. 
 
-###How do I navigate the Dashboard?
+### How do I navigate the Dashboard?
 
 An example of the Manager Dashboard is shown below. The functionalities are defined for each element of the Dashboard.
 

--- a/pages/planetusermanual.md
+++ b/pages/planetusermanual.md
@@ -120,7 +120,7 @@ A collection is a group of Resources based on topic/subject and intended use.  P
 
 ## How do I upload a Resource?
 
-1.  Log in as a **_Learner_**, **_Leader_**, or **_Manager_**.
+1.  Log in as a **Learner**, **Leader**, or **Manager**.
 
 2.  Start on the main **_Dashboard_** and click on the **_Library_** heading.
 

--- a/pages/takehome.md
+++ b/pages/takehome.md
@@ -1,8 +1,8 @@
 [Google Doc](https://docs.google.com/document/d/1JUePcj0W9mg6Ea__lakJK-Zd6ZFXchmqdbztLqIU4Cs/edit#heading=h.ieliyf4f8pjx)
 
-#Android "Take Home" Bell application development
+# Android "Take Home" Bell application development
 
-##Project Setup
+## Project Setup
 To be able to debug / repackage / build on the android mobile application, you need to:
 
 - download and install the most recent official IDE for android: [Android Studio](https://developer.android.com/studio/index.html) 

--- a/pages/team.md
+++ b/pages/team.md
@@ -18,6 +18,7 @@
 |[praneetharra](profiles/praneetharra.md)| 20170421 |
 |[shahswet](profiles/shahswet.md)| 20170501 |
 |[Yurockkk](profiles/Yurockkk.md)| 20170505 |
+|[sarah-lu102](profiles/sarah-lu102.md)| 20170510 |
 |[snazzybunny](profiles/snazzybunny.md)| 20170511 |
 
 ## Inactive Interns


### PR DESCRIPTION
Once again, these commits fix faulty header syntax as laid out in issue #770. This particular set of fixes deals with headers in "planetusermanual.md" and "takehome.md," fixing them  to conform with proper markdown syntax. Just like PR #793 this issue is a response to the list laid out by @mappuji to resolve various errors among the wiki pages.