### PR TITLE
Improve takehome.md(issue #805)

### DIFF
--- a/pages/takehome.md
+++ b/pages/takehome.md
@@ -4,19 +4,19 @@
 
 The [Take Home Application]( https://github.com/open-learning-exchange/take-home) is an Android application using Java, CouchDB and JSON. The goal of the project is to mimic BeLL Apps on a mobile scale to allow users to use an Android device to interact with MyBeLL.
 
-In here you will find step by step guides to getting the Take Home Application up and running in Android Studio. Once you are setup, please read the [Take Home Documentation](takeHomeDocumentation.md) so you can understand the flow of the application.
+In here you will find step by step guides to getting the Take Home Application up and running in Android Studio. You will also learn how to build deployment environments to test your code. There are two places where you can try out your code: **Android Device Emulator** and **Real Android Device**. We prefer to test our code on real android device because it is the same environment as our end user. You can figure out how your app performs when there is no internet connection or other circumstances that Android Device Emulator is not supported (read more [here](https://developer.android.com/studio/run/emulator.html)). Once you are setup, please read the [Take Home Documentation](takeHomeDocumentation.md) so you can understand the flow of the application.
 
 ## [Android Studio Setup](takeHomeAndroidStudioSetup.md)
 
 You will be using Android Studio to develop the Take Home Application. Within this guide, you will learn what is needed to get Android Studio installed and the application up and running.
 
-## [Android Device Emulator Setup](takeHomeEmulatorSetup.md)
-
-One of the deploment enviroments that you are going to be working in is Android Studio's Android device emulator. These steps will guide you to get the emulator up and running.
-
 ## [Android Device Setup](takeHomeDeviceSetup.md)
 
-The second deploment enviroment you will be testing on is an actually Android device. These steps will guide you to getting the Take Home Applicaiton running on an actually Android Device.
+One of the deployment environments you will be testing on is an actually Android device. These steps will guide you to getting the Take Home Applicaiton running on an actually Android Device.
+
+## [Android Device Emulator Setup](takeHomeEmulatorSetup.md)
+
+The second deployment environment that you are going to be working in is Android Studio's Android device emulator. These steps will guide you to get the emulator up and running.
 
 ## [Take Home Documentation](takeHomeDocumentation.md)
 


### PR DESCRIPTION
Improve takehome.md (issue [#805](https://github.com/open-learning-exchange/open-learning-exchange.github.io/issues/805)) by adding a paragraph about we prefer to test take-home app on real android device rather than android emulator and switch the order of “android device emulator setup” and “android device setup”

rawgit [here](https://rawgit.com/Yurockkk/Yurockkk.github.io/branchFor805/#!pages/takehome.md)