### PR TITLE
Alterations to step #9 (Resolution to Issue #779 )

### DIFF
--- a/pages/firststeps.md
+++ b/pages/firststeps.md
@@ -72,7 +72,6 @@ Head over to [Open Learning Exchange Repository](https://github.com/open-learnin
 * 5 merged pull requests (1 PR at step-3, 1 PR at step-6 and 3 PR's at step-8).
 * 4 comments (1 comment at step-6, 3 comment's at step-8)
 * 4 issues (1 issue at step-6, 3 issues at step-8)
-* You can count them [here](https://github.com/open-learning-exchange/open-learning-exchange.github.io/commits/master)
 
 If you meet these requirements let us know in the Gitter chat, so we can send the survey to your community. Then, fill out the survey and submit it. Next, Sync your community with the nation (as you did in step 7). Lastly, once you have completed all other steps, add yourself to the virtual intern list found in team.md and create a pull request.
 


### PR DESCRIPTION
As outlined in Issue #779, the final bullet point encouraging potential interns to count their links is marginally helpful at best, and misleading at worst. To that end, I simply removed it, as interns should be able to count their contributions themselves.