### PR TITLE
Changed 'two publication' to 'publication(s)' (Issue #941)

### DIFF
--- a/pages/nation.md
+++ b/pages/nation.md
@@ -43,7 +43,7 @@ Then, you should see a list of communities and the option to generate a report i
 ## Different Kinds of Update
 Above is the usual syncing process from the community side. There are three other important kinds of updates that you receive on the community side: updates, publications, and surveys.  
 
-As you can see from the image below, there is an update ready to be downloaded. Usually, next to the update, you should also see two publications ready to be downloaded. 
+As you can see from the image below, there is an update ready to be downloaded. Usually, next to the update, you should also see  publication(s) ready to be downloaded. 
 
 ![Update from the nation](uploads/images/update_publications.png)
 


### PR DESCRIPTION
Rawgit Link: https://rawgit.com/sagun98/sagun98.github.io/two_publication/#!./pages/nation.md

Changed the "two publication" to "publication(s)" in [nation bell](http://open-learning-exchange.github.io/#!./pages/nation.md) page as number of publication could be only one too. 
![imageedit_3_4120560348](https://user-images.githubusercontent.com/15079734/27251064-ecfe918e-5303-11e7-94aa-f8c6a1b60795.gif)
