### PR TITLE
#919 Add a Markdown tutorial in githubandmarkdown.md

### DIFF
--- a/pages/firststeps.md
+++ b/pages/firststeps.md
@@ -45,7 +45,6 @@ Review these [Vagrant instructions](vagrant.md) to ensure that you have fully co
 
 Follow the instructions on the [GitHub and Markdown page](githubandmarkdown.md). Make sure that you've linked to your github.io and your personal .md page on the [Gitter chat](https://gitter.im/open-learning-exchange/chat) (&lt;username&gt;.github.io and &lt;username&gt;.github.io/#!pages/profiles/&lt;username&gt;.md).
 
-Here is the tutorial as reference to work on the Step 3 and Step 5.
 Markdown Tutorial:
 [MarkdownTutorial](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet#links)
 

--- a/pages/firststeps.md
+++ b/pages/firststeps.md
@@ -45,6 +45,10 @@ Review these [Vagrant instructions](vagrant.md) to ensure that you have fully co
 
 Follow the instructions on the [GitHub and Markdown page](githubandmarkdown.md). Make sure that you've linked to your github.io and your personal .md page on the [Gitter chat](https://gitter.im/open-learning-exchange/chat) (&lt;username&gt;.github.io and &lt;username&gt;.github.io/#!pages/profiles/&lt;username&gt;.md).
 
+Here is the tutorial as reference to work on the Step 3 and Step 5.
+Markdown Tutorial:
+[MarkdownTutorial](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet#links)
+
 - Once you complete the Step 3 you will have:
     * 1 Pull request made
 

--- a/pages/firststeps.md
+++ b/pages/firststeps.md
@@ -45,8 +45,6 @@ Review these [Vagrant instructions](vagrant.md) to ensure that you have fully co
 
 Follow the instructions on the [GitHub and Markdown page](githubandmarkdown.md). Make sure that you've linked to your github.io and your personal .md page on the [Gitter chat](https://gitter.im/open-learning-exchange/chat) (&lt;username&gt;.github.io and &lt;username&gt;.github.io/#!pages/profiles/&lt;username&gt;.md).
 
-[Markdown Tutorial](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet#links)
-
 - Once you complete the Step 3 you will have:
     * 1 Pull request made
 

--- a/pages/firststeps.md
+++ b/pages/firststeps.md
@@ -45,8 +45,7 @@ Review these [Vagrant instructions](vagrant.md) to ensure that you have fully co
 
 Follow the instructions on the [GitHub and Markdown page](githubandmarkdown.md). Make sure that you've linked to your github.io and your personal .md page on the [Gitter chat](https://gitter.im/open-learning-exchange/chat) (&lt;username&gt;.github.io and &lt;username&gt;.github.io/#!pages/profiles/&lt;username&gt;.md).
 
-Markdown Tutorial:
-[MarkdownTutorial](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet#links)
+[Markdown Tutorial](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet#links)
 
 - Once you complete the Step 3 you will have:
     * 1 Pull request made

--- a/pages/githubandmarkdown.md
+++ b/pages/githubandmarkdown.md
@@ -20,6 +20,8 @@ Below is a cheat sheet of Markdown to help you create your own individual MD Wik
 
 ![Markdown Cheat Sheet](uploads/images/Markdown_Reference.png)
 
+[Markdown Tutorial](http://tylingsoft.com/tutorial.md/#whats-markdown)
+
 You can also find a bigger cheat sheet with examples [here](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 
 If you want more practice using Markdown, check out [this site](http://www.markdowntutorial.com/lesson/1/) to explore the MD syntax and see results as you type.


### PR DESCRIPTION
This PR resolves issue #919
Added a Markdown tutorial in githubandmarkdown.md.
[rawgit](https://rawgit.com/yoeng327/yoeng327.github.io/tutorial-branch-yoeng327/#!pages/githubandmarkdown.md)

![screen shot 2017-06-24 at 11 16 01 pm](https://user-images.githubusercontent.com/16061365/27513419-2f397cc8-5933-11e7-81de-b1d26854c6cd.png)



