### PR TITLE
Improve the structure of Take Home Project guides (issue #1017)

### DIFF
--- a/pages/takeHomeAndroidStudioSetup.md
+++ b/pages/takeHomeAndroidStudioSetup.md
@@ -11,6 +11,10 @@ To be able to debug / repackage / build on the android mobile application, you n
 
 - Select whether you want to import previous Android Studio settings, then click OK.
 
+- GitHub Setting
+
+- Take Home Project Setup
+
 ---
 
 The Android Studio Setup Wizard guides you through the rest of the setup, which includes downloading Android SDK components that are required for development. 
@@ -18,7 +22,7 @@ The Android Studio Setup Wizard guides you through the rest of the setup, which 
 
 ![AndroidSDKManager](uploads/images/AndroidSDKManager.png)
 
-###GitHub setting
+### GitHub setting
 There are three steps that needs be done before you can make contribution to "take-home" project:
 
 1. Find and fork the "take-home" repository
@@ -37,24 +41,14 @@ Navigate to Android studio -> take-home and select the settings.gradle file to i
 >http://stackoverflow.com/questions/37397810/android-studio-unable-to-run-avd
 >https://www.virtualbox.org/ticket/14294 NB Virtualbox version needs lower equal 4.3.28
 
-- Click on the run button located at the top of your IDE. You will be prompted to Select Deployment Target. Select “Create New Emulator” button.
+### Take Home Project Setup
+When you try to run the app now you will get an error saying you are missing two .apk files. You can find the following files here:
 
-![AndroidDeploymentTarget](uploads/images/AndroidDeploymentTarget.png)
+- [firefox_49_0_multi_android.apk](https://drive.google.com/file/d/0Bw7aA5bLT2P9TTBNSDl3VzgtVnc/view)
+- [adobe_reader.apk](https://drive.google.com/open?id=0Bw7aA5bLT2P9UmhlcHA1R1BoZnM) 
 
-- Select a device definition from the list provided and click the next button
-           
-![AndroidHardwareSelection](uploads/images/AndroidHardwareSelection.png)
+Download both files and put them into the take-home raw folder found here:
 
-- Select system image from the list shown. API Level 22 and above works best. Preferably, choose 22 with Android 5.1. Click next to continue.
-	
-![AndroidMarshmellowSystem](uploads/images/AndroidMarshmellowSystem.png)
+- take-home\app\src\main\res\raw
 
-- Name the emulator and specify the necessary configuration as shown below. Click on finish to save the emulator. 
-	
-![AndroidVirtualDevice](uploads/images/AndroidVirtualDevice.png)
-
-- You will be presented with the “Select Deployment Target” dialogue again . Choose the emulator we just created and click on the “OK” button.
-
-![AndroidDeploymentTarget](uploads/images/AndroidDeploymentTarget.png)
-
-- The emulator will be opened with application installed. You have successfully configured the development environment to get you started.
+Now, The Take Home Project is ready to run on an Android device or an Android Emulator. Check out [Android Device Setup](takeHomeDeviceSetup.md) and [Android Device Emulator Setup](takeHomeEmulatorSetup.md) for more details.

--- a/pages/takeHomeEmulatorSetup.md
+++ b/pages/takeHomeEmulatorSetup.md
@@ -13,27 +13,29 @@ Download both files and put them into the take-home raw folder found here:
 
 - take-home\app\src\main\res\raw
 
-The app is now ready to run on an Android device. If you would like to run it in Android Studio's virtual device you made, you will have to modify the code as follows.
+The app is now ready to run on an Android device. If you would like to run it in Android Studio's virtual device, you will have to create a new emulator as follows.
 
-In Android Studio:
-- Navigate to app-> java-> pbell.offline.ole.org.pbell-> FullscreenLogin
-- Find ```public boolean updateActivityLog()```
-- Comment out the line containing ```String m_WLANMAC = wm.getConnectionInfo().getMacAddress();```
-- Add this line below the one you just commented out ```String m_WLANMAC = "mymac";```
+1. Click on the run button located at the top of your IDE. You will be prompted to Select Deployment Target. Select “Create New Emulator” button.
 
-Your code should now look like this:
+![AndroidDeploymentTarget](uploads/images/AndroidDeploymentTarget.png)
 
-![AndroidFullscreenLoginMod](uploads/images/AndroidFullscreenLoginMod.png)
+2. Select a device definition from the list provided and click the next button
+           
+![AndroidHardwareSelection](uploads/images/AndroidHardwareSelection.png)
 
-Again, In Android Studio:
-- Navigate to app->java-> pbell.offline.ole.org.pbell-> FullscreenActivity
-- Find ```public boolean updateActivityOpenedResources(String resource_name, String resourceid)```
-- Comment out the line containing ```String m_WLANMAC = wm.getConnectionInfo().getMacAddress();```
-- Add this line below the one you just commented out ```String m_WLANMAC = "mymac";```
+3. Select system image from the list shown. API Level 22 and above works best. Preferably, choose 22 with Android 5.1. Click next to continue.
+	
+![AndroidMarshmellowSystem](uploads/images/AndroidMarshmellowSystem.png)
 
-Your code should look like this:
+4. Name the emulator and specify the necessary configuration as shown below. Click on finish to save the emulator. 
+	
+![AndroidVirtualDevice](uploads/images/AndroidVirtualDevice.png)
 
-![AndroidscreenActivity](uploads/images/AndroidscreenActivityMod.png)
+5. You will be presented with the “Select Deployment Target” dialogue again . Choose the emulator we just created and click on the “OK” button.
+
+![AndroidDeploymentTarget](uploads/images/AndroidDeploymentTarget.png)
+
+6. The emulator will be opened with application installed. You have successfully configured the development environment to get you started.
 
 Now you should be able to run the app in your virtual device.
 

--- a/pages/takeHomeEmulatorSetup.md
+++ b/pages/takeHomeEmulatorSetup.md
@@ -4,16 +4,7 @@ One of the deploment enviroments that you are going to be working in is Android 
 
 ## Android Studio Emulator Setup
 
-When you first run the app you will get an error saying you are missing two .apk files. You can find the following files here:
-
-- [firefox_49_0_multi_android.apk](https://drive.google.com/file/d/0Bw7aA5bLT2P9TTBNSDl3VzgtVnc/view)
-- [adobe_reader.apk](https://drive.google.com/open?id=0Bw7aA5bLT2P9UmhlcHA1R1BoZnM) 
-
-Download both files and put them into the take-home raw folder found here:
-
-- take-home\app\src\main\res\raw
-
-The app is now ready to run on an Android device. If you would like to run it in Android Studio's virtual device, you will have to create a new emulator as follows.
+To run the app in Android Studio's virtual device, you will have to create a new emulator as follows.
 
 * Click on the run button located at the top of your IDE. You will be prompted to Select Deployment Target. Select “Create New Emulator” button.
 

--- a/pages/takeHomeEmulatorSetup.md
+++ b/pages/takeHomeEmulatorSetup.md
@@ -15,27 +15,27 @@ Download both files and put them into the take-home raw folder found here:
 
 The app is now ready to run on an Android device. If you would like to run it in Android Studio's virtual device, you will have to create a new emulator as follows.
 
-1. Click on the run button located at the top of your IDE. You will be prompted to Select Deployment Target. Select “Create New Emulator” button.
+* Click on the run button located at the top of your IDE. You will be prompted to Select Deployment Target. Select “Create New Emulator” button.
 
 ![AndroidDeploymentTarget](uploads/images/AndroidDeploymentTarget.png)
 
-2. Select a device definition from the list provided and click the next button
+* Select a device definition from the list provided and click the next button
            
 ![AndroidHardwareSelection](uploads/images/AndroidHardwareSelection.png)
 
-3. Select system image from the list shown. API Level 22 and above works best. Preferably, choose 22 with Android 5.1. Click next to continue.
+* Select system image from the list shown. API Level 22 and above works best. Preferably, choose 22 with Android 5.1. Click next to continue.
 	
 ![AndroidMarshmellowSystem](uploads/images/AndroidMarshmellowSystem.png)
 
-4. Name the emulator and specify the necessary configuration as shown below. Click on finish to save the emulator. 
+* Name the emulator and specify the necessary configuration as shown below. Click on finish to save the emulator. 
 	
 ![AndroidVirtualDevice](uploads/images/AndroidVirtualDevice.png)
 
-5. You will be presented with the “Select Deployment Target” dialogue again . Choose the emulator we just created and click on the “OK” button.
+* You will be presented with the “Select Deployment Target” dialogue again . Choose the emulator we just created and click on the “OK” button.
 
 ![AndroidDeploymentTarget](uploads/images/AndroidDeploymentTarget.png)
 
-6. The emulator will be opened with application installed. You have successfully configured the development environment to get you started.
+* The emulator will be opened with application installed. You have successfully configured the development environment to get you started.
 
 Now you should be able to run the app in your virtual device.
 


### PR DESCRIPTION
[**CHANGE**]

Improve the structure of take home project guides:
1. Delete unneeded contents in **takeHomeEmulatorSetup.md**

2. Move "Select Deployment Target" from **takeHomeAndroidStudioSetup.md** to **takeHomeEmulatorSetup.md** 

    _(Only Android Emulator needs this step so I move it to takeHomeEmulatorSetup.md)_

3. Move "APK Installation" from **takeHomeEmulatorSetup.md** to **takeHomeAndroidStudioSetup.md**

    _(Both Android Device and Android Emulator need this step so I move it to takeHomeAndroidStudioSetup.md and name it "Take Home Project Setup")_

[**RESULT**]

rawgit:
        [takeHomeAndroidStudioSetup](https://rawgit.com/Yurockkk/Yurockkk.github.io/issue1017/#!./pages/takeHomeAndroidStudioSetup.md)
        [takeHomeEmulatorSetup](https://rawgit.com/Yurockkk/Yurockkk.github.io/issue1017/#!./pages/takeHomeEmulatorSetup.md)

reference issue: [issue 1017](https://github.com/open-learning-exchange/open-learning-exchange.github.io/issues/1017)