### PR TITLE
Add steps for install development environment for MacOS/Ubuntu

### DIFF
--- a/pages/automatedtestingpython.md
+++ b/pages/automatedtestingpython.md
@@ -72,10 +72,19 @@ Finally:
 
 ## MacOS/Ubuntu - Installing Testing Development Environment
 ### Installing Nation
-WIP - Needs some love.
+The process is similar to installing Nation for Windows.
 
 ### Installing Python, Pip, Selenium, Geckodriver, and Firefox
-WIP - Needs some love.
+1. Install Python 3 with `brew install python3` or download Python from https://www.python.org/downloads/release/python-352/)
+2. Restart the cmd window
+3. pip3 is already included when you install python3
+4. Check if you installed them correctly, typing `python3 --version` and `pip3 --version`
+    If you want to use python virtual environment, refer to step 4 on Windows section
+5. Type `pip3 install selenium`
+6. Download **geckodriver** from https://github.com/mozilla/geckodriver/releases  
+7. Add **geckodriver** to the PATH
+
+Steps 8-13 are similar to the Windows section    
 
 ## Daily Workflow (waffle.io tutorial)
 


### PR DESCRIPTION
Hi @dogi, @kylemathias, @sarah-lu102,  I added the Mac section for install development environment. Please take a look.  Here is [rawgit link](http://rawgit.com/duongdo27/open-learning-duongdo.github.io/update_automated_testing_for_mac/#!./pages/automatedtestingpython.md#MacOS/Ubuntu_-_Installing_Testing_Development_Environment) 