### PR TITLE
update link in faq.md (fix #1104)

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -141,7 +141,8 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 - [Markdown Syntax](https://daringfireball.net/projects/markdown/syntax)
 - [Markdown Cheat Sheet (PDF)](https://enterprise.github.com/downloads/en/markdown-cheatsheet.pdf)
 - [Markdown Editor](https://jbt.github.io/markdown-editor/)
-- [Vi Cheat Sheet](https://vim.rtorr.com/)
+- [Vi Cheat Sheet (PDF)](https://www.shell-tips.com/sheets/vi_help_sheet.pdf)
+- [Vim Cheat Sheet](https://vim.rtorr.com/)
 
 #### *VirtualBox*
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -142,7 +142,6 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 - [Markdown Cheat Sheet (PDF)](https://enterprise.github.com/downloads/en/markdown-cheatsheet.pdf)
 - [Markdown Editor](https://jbt.github.io/markdown-editor/)
 - [Vi Cheat Sheet (PDF)](https://www.shell-tips.com/sheets/vi_help_sheet.pdf)
-- [Vim Cheat Sheet](https://vim.rtorr.com/)
 
 #### *VirtualBox*
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -141,7 +141,7 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 - [Markdown Syntax](https://daringfireball.net/projects/markdown/syntax)
 - [Markdown Cheat Sheet (PDF)](https://enterprise.github.com/downloads/en/markdown-cheatsheet.pdf)
 - [Markdown Editor](https://jbt.github.io/markdown-editor/)
-- [Vi Cheat Sheet (JPG)](https://www.shell-tips.com/sheets/vi_help_sheet.jpg)
+- [Vi Cheat Sheet](https://vim.rtorr.com/)
 
 #### *VirtualBox*
 


### PR DESCRIPTION
Issue #1104 

[rawgit](https://rawgit.com/xyb994/xyb994.github.io/replace-vi-cheat-sheet/#!./pages/faq.md#GitHub_and_Markdown)

- Replaced the original vim cheat sheet link with its same pdf version

