### PR TITLE
Add Vagrant instruct link (fix #1140)

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -68,6 +68,8 @@ cd ole--vagrant-vi
 vagrant up
 ```
 
+**NOTE**: Refer to the Prerequisites section of [Vagrant instructions](vagrant.md) if you encountered an error while executing the command `vagrant up`
+
 You now have a working [community BeLL](http://127.0.0.1:5985/apps/_design/bell/MyApp/index.html) on your OS.    
 It is advisable to use Firefox to access your community BeLL, so if you don't have it already on your system, you may want to download it.
 


### PR DESCRIPTION
Added a note under "MacOS(X) and Ubuntu ONLY" section of the installation page.

[rawgit](https://rawgit.com/hmly/hmly2.github.io/install-link/#!./pages/installation.md)