### PR TITLE
Mispelt word at vagrant.md (issue #1197)

### DIFF
--- a/pages/profiles/cramartef.md
+++ b/pages/profiles/cramartef.md
@@ -1,5 +1,0 @@
-#Fetra Marc Humbert Rahajason
-
-Madagascar/GMT+3:00, East Africa Time, windows 10 pro
-
-I am a OLE leader

--- a/pages/profiles/cramartef.md
+++ b/pages/profiles/cramartef.md
@@ -1,0 +1,5 @@
+#Fetra Marc Humbert Rahajason
+
+Madagascar/GMT+3:00, East Africa Time, windows 10 pro
+
+I am a OLE leader

--- a/pages/vagrant.md
+++ b/pages/vagrant.md
@@ -73,7 +73,7 @@ You may want to try and issue the above commands on your system, to get familiar
 
 ## macOS
 - Open your `Terminal`. We assume that [brew](http://brew.sh/) is already installed.
-> The first step is locating to the local folder you have designated to do your work in. If you have a different locaiton than the one you see in the first step, replace the "OLE" with the directory to your folder. 
+> The first step is locating to the local folder you have designated to do your work in. If you have a different location than the one you see in the first step, replace the "OLE" with the directory to your folder. 
 
 ```
     cd OLE


### PR DESCRIPTION
Correction of the word 'locaiton'. [rawgit page](https://rawgit.com/cramartef/cramartef.github.io/branch03-cramartef/#!pages/vagrant.md#macOS)