### PR TITLE
Updated the 404 link issue #1455

### DIFF
--- a/pages/vi/vi-vagrant.md
+++ b/pages/vi/vi-vagrant.md
@@ -162,7 +162,7 @@ or not commonly used. To see all subcommands, run the command
 ## Useful  Links
 
 [Instructions to install Vagrant - README.md](https://github.com/dogi/ole--vagrant-vi)
-[Why install Vagrant?](https://www.vagrantup.com/docs/why-vagrant/) - Explanation of some basic concepts about why Vagrant is useful for developers, operators and designers.
+[Why install Vagrant?]https://www.vagrantup.com/intro/index.html) - Explanation of some basic concepts about why Vagrant is useful for developers, operators and designers.
 [Vagrant download](https://www.vagrantup.com/downloads.html)
 [Wikipedia page on Vagrant](https://en.wikipedia.org/wiki/Vagrant_%28software%29)
 [Other helpful links and videos](vi-faq.md#Helpful_Links)

--- a/pages/vi/vi-vagrant.md
+++ b/pages/vi/vi-vagrant.md
@@ -162,7 +162,7 @@ or not commonly used. To see all subcommands, run the command
 ## Useful  Links
 
 [Instructions to install Vagrant - README.md](https://github.com/dogi/ole--vagrant-vi)
-[Why install Vagrant?]https://www.vagrantup.com/intro/index.html) - Explanation of some basic concepts about why Vagrant is useful for developers, operators and designers.
+[Why install Vagrant?](https://www.vagrantup.com/intro/index.html) - Explanation of some basic concepts about why Vagrant is useful for developers, operators and designers.
 [Vagrant download](https://www.vagrantup.com/downloads.html)
 [Wikipedia page on Vagrant](https://en.wikipedia.org/wiki/Vagrant_%28software%29)
 [Other helpful links and videos](vi-faq.md#Helpful_Links)


### PR DESCRIPTION
Changed the 404 link into a link that has content.

https://rawgit.com/TooManySpaces/TooManySpaces.github.io/whyVagrant/#!pages/vi/vi-vagrant.md