### PR TITLE
changed example profile link to correct link #1462

### DIFF
--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -111,7 +111,7 @@ Often there will be some feedback from the reviewer at this point for you to add
 
 After the pull request is completed, you'll be able to see this on open-learning-exchange.github.io in addition to your personal page. Let us know when you have completed this step in the [gitter.im chat](https://gitter.im/open-learning-exchange/chat).
 
-**NOTE**: Try to add and experiment with as many markdown elements as you can and make your page attractive. A list of sample profile pages can be found [**here**](https://github.com/open-learning-exchange/open-learning-exchange.github.io/tree/master/vi/pages/profiles). Be creative.  
+**NOTE**: Try to add and experiment with as many markdown elements as you can and make your page attractive. A list of sample profile pages can be found [**here**](https://github.com/open-learning-exchange/open-learning-exchange.github.io/tree/master/pages/vi/profiles). Be creative.  
 Make sure to include a rawgit link to your page in your pull request.
 
 ## Useful Links


### PR DESCRIPTION
Changed the example profile link into a link that has content.

https://rawgit.com/ketruong/ketruong.github.io/issue1462/#!pages/vi/vi-github-and-markdown.md