### PR TITLE
Fix wrong example rawgit link (fix #1449)

### DIFF
--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -93,7 +93,7 @@ If you need to edit your file again, just click the pencil icon to edit (as show
 
   ![Edit Profile](images/vi-edit-profile.png)
 
-Now, check what this looks like on your own page `https://rawgit.com/YourUserName/YourUserName.github.io/YourBranchName/#!pages/vi/Profiles/YourUserName.md` and post a link to it in the [gitter.im chat](https://gitter.im/open-learning-exchange/chat). Check and double check that everything looks good and is working before initiating a pull request.
+Now, check what this looks like on your own page `https://rawgit.com/YourUserName/YourUserName.github.io/YourBranchName/#!pages/vi/profiles/YourUserName.md` and post a link to it in the [gitter.im chat](https://gitter.im/open-learning-exchange/chat). Check and double check that everything looks good and is working before initiating a pull request.
 
 **NOTE**: If you don't see any changes in your page after editing your file then you need to clear your browser's cache or open your page in your browser's **"incognito"** or **"privacy"** mode. You can also press Ctrl+Shift+R or Ctrl+F5 to reload the page with cache cleared.
 

--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -93,7 +93,7 @@ If you need to edit your file again, just click the pencil icon to edit (as show
 
   ![Edit Profile](images/vi-edit-profile.png)
 
-Now, check what this looks like on your own page `https://rawgit.com/YourUserName/YourUserName.github.io/YourBranchName/#!pages/profiles/vi/YourUserName.md` and post a link to it in the [gitter.im chat](https://gitter.im/open-learning-exchange/chat). Check and double check that everything looks good and is working before initiating a pull request.
+Now, check what this looks like on your own page `https://rawgit.com/YourUserName/YourUserName.github.io/YourBranchName/#!pages/vi/Profiles/YourUserName.md` and post a link to it in the [gitter.im chat](https://gitter.im/open-learning-exchange/chat). Check and double check that everything looks good and is working before initiating a pull request.
 
 **NOTE**: If you don't see any changes in your page after editing your file then you need to clear your browser's cache or open your page in your browser's **"incognito"** or **"privacy"** mode. You can also press Ctrl+Shift+R or Ctrl+F5 to reload the page with cache cleared.
 


### PR DESCRIPTION
Corrected the right Gitraw Link.

Preview: https://rawgit.com/Jackbui96/Jackbui96.github.io/issue1449/#!pages/vi/vi-github-and-markdown.md

Before:
![github and markdown - mozilla firefox_017](https://user-images.githubusercontent.com/15133304/34790649-3b55e404-f5f7-11e7-91e4-31525f328150.png)

After:
![github and markdown - mozilla firefox_022](https://user-images.githubusercontent.com/15133304/34919725-dd56f374-f91c-11e7-85d8-0ef5de7499df.png)

Duplicate of PR#1450, I recreate the issue so that the work flow will make more sense. So if this issue is resolved and close, please also close PR#1450. Thank you.