### PR TITLE
Github Issue section Improvement (Issue #1467)

### DIFF
--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -107,5 +107,6 @@ This is an exercise to help you familiarize with GitHub issues, committing, and 
 
 [Mastering Issues](https://guides.github.com/features/issues/) - The official Git Guide on the basics of filing an issue.
 [Helpful links and videos](vi-faq.md#Helpful_Links)
+[How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)  
 
 #### Return to [First Steps](vi-first-steps.md#Step_6_-_GitHub_Issues_Tutorial)

--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -106,7 +106,7 @@ This is an exercise to help you familiarize with GitHub issues, committing, and 
 ## Useful Links
 
 [Mastering Issues](https://guides.github.com/features/issues/) - The official Git Guide on the basics of filing an issue.
-[Helpful links and videos](vi-faq.md#Helpful_Links)  
-[How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)  
+[Helpful links and videos](vi-faq.md#Helpful_Links)
+[How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 
 #### Return to [First Steps](vi-first-steps.md#Step_6_-_GitHub_Issues_Tutorial)

--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -106,7 +106,7 @@ This is an exercise to help you familiarize with GitHub issues, committing, and 
 ## Useful Links
 
 [Mastering Issues](https://guides.github.com/features/issues/) - The official Git Guide on the basics of filing an issue.
-[Helpful links and videos](vi-faq.md#Helpful_Links)
+[Helpful links and videos](vi-faq.md#Helpful_Links)  
 [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)  
 
 #### Return to [First Steps](vi-first-steps.md#Step_6_-_GitHub_Issues_Tutorial)


### PR DESCRIPTION
Adding a link https://opensource.guide/how-to-contribute/ to "How to Contribute to Open Source" under Useful Links under GitHub Issue section.  
 
![image](https://user-images.githubusercontent.com/24216313/34973114-bba79fac-fa3a-11e7-9167-e299ae241068.png)


https://rawgit.com/ofrank23447/ofrank23447.github.io/issue1467/#!./pages/vi/vi-github-issues.md