### PR TITLE
Updated note in Installation Steps ( Fix #1512 )

### DIFF
--- a/pages/robots/rbts-raspberry-pi.md
+++ b/pages/robots/rbts-raspberry-pi.md
@@ -34,7 +34,7 @@ We meet on Wednesdays at 4:30 PM EST online on [http://talk.ole.org](http://talk
 
 ## How can I help?
 
-So far we are working on creating a seamless experience for the image, meaning we want the user to have many connectivity options without having to tinker too much with the Raspberry Pi. So our main concerns at the moment is getting the RPI to connect to different connectivity options such as wifi/bluetooth/ethernet automatically. This allows more people to contribute and debug unexpected problems. Once we have those bases covered, we can move onward to the software part. 
+So far we are working on creating a seamless experience for the image, meaning we want the user to have many connectivity options without having to tinker too much with the Raspberry Pi. So our main goal at the moment is getting the RPI to connect to different connectivity options such as wifi/bluetooth/ethernet automatically. This allows more people to contribute and debug unexpected problems. Once we have those bases covered, we can move onward to the software part. 
 
 There is always something to be done. Check the [GitHub issues](https://github.com/ole-vi/treehouse-builder/issues) for treehouse-builder to see what needs to be done or [waffle.io](https://waffle.io/ole-vi/treehouse-builder). Once you've chosen an issue and fixed the problem, create a PR using the same guidelines as the ones used when you had to go through the intern orientation. If you have any questions, just ask! You can find us on the #raspberrypi channel on gitter.
 
@@ -73,7 +73,7 @@ Below we have a short step-by-step rundown of how the treehouse-builder works:
  - Install packages needed for OLE such as docker and matchbox-keyboard
  - Run autorun script
 4. Enter chroot if user needs to perform additional commands
-5. Write the .img file with a program such as Etcher to the MicroSD card.
+5. Write the .img file with a program such as Etcher to the MicroSD card
 
 ## List of Relevant Repositories & Links
 

--- a/pages/robots/rbts-raspberry-pi.md
+++ b/pages/robots/rbts-raspberry-pi.md
@@ -15,7 +15,9 @@ Since ole--vagrant-treehouses creates a virtual machine, it works on all platfor
 - Any RPI for testing the microSD card
 - A class10 microSD card (minimum 8 Gb) new image to the class10 microSD card
 - microSD card reader/writer for writing the
+
 **Building the image with treehouse-builder:**
+
 - Ubuntu or Debian based Linux distribution (Other distros are untested)
 - An Internet connection
 

--- a/pages/vi/profiles/ofrank23447.md
+++ b/pages/vi/profiles/ofrank23447.md
@@ -1,0 +1,18 @@
+# Welcome!!
+### San Jose, CA / PST / Windows 10
+
+My name is Young-Taek Oh or some people call me Frank.
+I graduate from Purdue University in December 2017 with Computer Engineering.
+I will be entering the graduate school in Fall 2018 for Computer Science program.
+I am experienced in an array of hardware and software aspects of programming. 
+I've done projects in ASIC design with Verilog and embedded design wtih Embedded-C. 
+In addition, interactive projects with higher programming languages like Java, Python, and C++.
+
+**Languages**: C | C++ | Java | JavaScript | Matlab | Python
+
+
+**Hobbies**: Basketball | Gaming | Cooking
+  
+  Feel free to contact me!  
+  [Linkedln](https://www.linkedin.com/in/young-taek/)
+  [github](https://www.github.com/ofrank23447)

--- a/pages/vi/vi-vagrant.md
+++ b/pages/vi/vi-vagrant.md
@@ -57,7 +57,7 @@ What this screen tells you is that you have a Vagrant virtual machine called `vi
 
 As you can see, in our case, the state of our machine is `running`. However, you can suspend your virtual machine issuing the command `vagrant suspend` or you can stop it completely with `vagrant halt`. In both cases, if you want to restart your machine, you will need to issue the command `vagrant up`.
 
-**NOTE**: If the command `vagrant up` is showing error i.e. if virtual box state is still poweroff after using `vagrant up` command then there is some problem with the vitual box. Re-installing newer version of [Virtual Box(Version 5.1.x)](https://www.virtualbox.org/wiki/Download_Old_Builds_5_1) will fix this problem. Also, do not download virtual box version 5.2 or 5.2+ as it is not supported by current vagrant installations.
+**NOTE**: If the command `vagrant up` is showing error i.e. if virtual box state is still poweroff after using `vagrant up` command then there is some problem with the vitual box. Re-installing newer version of [Virtual Box Version 5.1.x](https://www.virtualbox.org/wiki/Download_Old_Builds_5_1) will fix this problem. Also, do not download virtual box version 5.2 or 5.2+ as it is not supported by current vagrant installations.
 
 When you issue the command `vagrant suspend`, your machine state will become `saved`, and after issuing `vagrant up` the machine will restart exactly from the point is was at when you suspended it. On the other hand, when you issue the command `vagrant halt`, the state will become `poweroff`, and after issuing `vagrant up` the machine will restart from the initial state it was at when you first installed it.
 


### PR DESCRIPTION
Adding note in **vi-vagrant.md** to solve virtual box crash issue in windows 10 64 bit systems.
https://rawgit.com/vishwakarmaanil/vishwakarmaanil.github.io/branch_add_note/pages/vi/vi-vagrant.md
NOTE: If the command vagrant up is showing error i.e. if virtual box state is still poweroff after using vagrant up command then there is some problem with the vitual box. Re-installing newer version of Virtual Box(Version 5.1.x) will fix this problem. Also, do not download virtual box version 5.2 or 5.2+ as it is not supported by current vagrant installations.