### PR TITLE
Changed explanation wording - (Issue #1594)

### DIFF
--- a/pages/vi/vi-chat.md
+++ b/pages/vi/vi-chat.md
@@ -6,7 +6,7 @@ Our **Gitter** chat, previewed below, is a great place to learn, discuss, and co
 
 Communication is key in every collaborative project, and OLE is no different. Gitter provides tight integration with *Github* and provides full rich text support through **Markdown**, an important tool for clean, efficient communication. Combining these features allows members to mention other members in a message, format text, share images and code, and directly link to Github issues and repositories.
 
-*To add images in the chat, just drag the image from your directory to the browser context and drop it in the messaging area or simply use Ctrl+C and Ctrl+V to paste your image.*
+*To add images in the chat, just drag the image from your directory to the browser context and drop it in the messaging area or simply copy and paste your image.*
 
 As you complete the [First Steps](vi-first-steps.md), we want you to keep us updated a relatively good amount in the Gitter chat. Generally, you should comment in the Gitter chat when you make an issue or pull request, and then link to it. Make a mention (@*name*) of someone when you comment on their issue/pull request, then link to it. For example:
 


### PR DESCRIPTION
https://raw.githubusercontent.com/Going-Gone/Going-Gone.github.io/copyAndPaste/pages/vi/vi-chat.md

![image](https://user-images.githubusercontent.com/28640954/35463819-32d05b70-02b8-11e8-85aa-d3a05261d5ef.png)

[x] Changed the previous explanation for copy and paste so that it can be more understood across all platforms.