### PR TITLE
Update dead link to vi-bell-installation.md (fixes #1695)

### DIFF
--- a/navigation.md
+++ b/navigation.md
@@ -43,7 +43,7 @@
   * [Tablet Configuration](pages/techgenius/tg-tablet-config.md)
   * [Community Installation](pages/techgenius/tg-install.md)
   * [Community Installation / RPi3](pages/techgenius/tg-rp3-installation.md)
-  * [Manual / Full Installation](pages/techgenius/tg-installation.md)
+  * [Manual / Full Installation](pages/vi/vi-bell-installation.md)
   * [Admin User Manual](pages/techgenius/tg-planet-user-manual.md)
   - - - -
   * [Content & Library Management](pages/techgenius/tg-library-management.md)


### PR DESCRIPTION
https://rawgit.com/Tille88/Tille88.github.io/dead_link_tg_install/#!pages/vi/vi-bell-installation.md

Link from Nav Bar => Tech Geniuses => Manual/Full Installation now working