### PR TITLE
Completing vi-former-members.md (#1657)

### DIFF
--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -27,15 +27,15 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[ChenjieZhou](profiles/ChenjieZhou.md)| 2017-06-10 |
 |[adhikara](profiles/adhikara.md)| 2017-06-16 |
 |[sagun98](profiles/sagun98.md)| 2017-06-22 |
-|[NavneetKarnam](profiles/navneetkarnam.md)| 2017-06-26 |
-|[tjyothsna16](profiles/tjyothsna16.md)| 2017-06-27 |
-|[prajwalajayaprakash](profiles/prajwalajayaprakash.md)| 2017-06-30 |
-|[daisywatson](profiles/daisywatson.md)| 2017-07-12 |
-|[alexkarasik](profiles/alexkarasik.md)| 2017-07-17 |
-|[l0rd3141](profiles/l0rd3141.md)| 2017-08-01 |
-|[sahityaLMaruvada](profiles/sahityaLMaruvada.md)| 2017-08-14 |
-|[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 |
-|[thesiege208](profiles/thesiege208.md)| 2017-10-16 |
+|[NavneetKarnam](profiles/navneetkarnam.md)| 2017-06-26 | 2017-07-19
+|[tjyothsna16](profiles/tjyothsna16.md)| 2017-06-27 | 2017-07-07
+|[prajwalajayaprakash](profiles/prajwalajayaprakash.md)| 2017-06-30 | 2017-08-09
+|[daisywatson](profiles/daisywatson.md)| 2017-07-12 | *2017-07-20*
+|[alexkarasik](profiles/alexkarasik.md)| 2017-07-17 | 2017-08-22
+|[l0rd3141](profiles/l0rd3141.md)| 2017-08-01 | *2017-08-01*
+|[sahityaLMaruvada](profiles/sahityaLMaruvada.md)| 2017-08-14 | *2017-08-17*
+|[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 | 2017-11-07
+|[thesiege208](profiles/thesiege208.md)| 2017-10-16 | 2018-01-03 
 |[aas919](profiles/aas919.md)| 2017-10-23 |2018-02-10
 |[mappuji](profiles/mappuji.md) (**Intern Lead**)| 2017-01-22 |2017-05-29 |
 |[𝖂𝖆𝖗𝖞𝖍𝖊𝖗𝖒𝖎𝖙](profiles/waryhermit.md) (**Intern Lead**)| 2016-12-13 | 2017-04-28 |

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -26,7 +26,7 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[kanishk1010](profiles/kanishk1010.md)| 2017-06-10 |
 |[ChenjieZhou](profiles/ChenjieZhou.md)| 2017-06-10 |
 |[adhikara](profiles/adhikara.md)| 2017-06-16 |
-|[sagun98](profiles/sagun98.md)| 2017-06-22 |
+|[sagun98](profiles/sagun98.md)| 2017-06-22 | 2017-07-22
 |[NavneetKarnam](profiles/navneetkarnam.md)| 2017-06-26 | 2017-07-19
 |[tjyothsna16](profiles/tjyothsna16.md)| 2017-06-27 | 2017-07-07
 |[prajwalajayaprakash](profiles/prajwalajayaprakash.md)| 2017-06-30 | 2017-08-09

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -14,7 +14,7 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[Chris-Boe](profiles/Chris-Boe.md)| 2017-02-26 |
 |[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 |
 |[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 |
-|[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 |
+|[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
 |[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17
 |[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19
 |[shahswet](profiles/shahswet.md)| 2017-05-01 | 2017-05-03

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -16,7 +16,6 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
 |[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17
 |[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19
-|[shahswet](profiles/shahswet.md)| 2017-05-01 | 2017-05-03
 |[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 | 2017-08-24
 |[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 | 2017-07-31
 |[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 | 2017-11-30
@@ -39,7 +38,6 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[FanisGk](profiles/FanisGk.md)| 2016-08-01 | 2017-01-31 |
 |[prmurphy](profiles/prmurphy.md)| 2016-10-23 | 2017-01-31 |
 |[aberdean](profiles/aberdean.md) (**Intern Lead**)| 2016-09-04 | 2016-12-23 |
-|[IshanSoni](profiles/IshanSoni.md)| 2016-12-20 | 2016-12-20 |
 |[mepda](profiles/mepda.md)| 2016-10-20 | 2016-12-18 |
 |[EmilyLarkin](profiles/EmilyLarkin.md) (**Intern Lead**)| 2016-03-01 | 2016-08-31 |
 |[DrewPerlman](profiles/DrewPerlman.md) (**Intern Lead**)| 2016-06-20 | 2016-08-14 |
@@ -52,6 +50,5 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[Neha1990](profiles/Neha1990.md)| 2016-07-12 | 2016-09-26 |
 |[cw-lin](profiles/cw-lin.md)| 2016-07-22 | 2016-09-14 |
 |[epistulae](profiles/epistulae.md)| 2016-06-01 | 2016-07-01 |
-|[pranesh-s](profiles/pranesh-s.md)| 2016-05-25 | 2016-06-03 |
+|[pranesh-s](profiles/pranesh-s.md)| 2016-05-25 | 2016-09-05 |
 |[314159265359](profiles/314159265359.md)| 2016-05-23 | 2016-06-03 |
-|[fangninghe](profiles/fangninghe.md)| 2017-01-23 | 2017-01-23 |

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -8,11 +8,11 @@ To view the list of current members, go to [active members page](vi-team.md).
 
 |**Username**|**Join Date**|**Leave Date**|
 |------------|-------------|--------------|
-|[hikaruit15](profiles/hikaruit15.md)| 2016-11-17 |
-|[hannahgdubin](profiles/hannahgdubin.md)| 2017-01-01 |
-|[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 |
-|[Chris-Boe](profiles/Chris-Boe.md)| 2017-02-26 |
-|[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 |
+|[hikaruit15](profiles/hikaruit15.md)| 2016-11-17 | 2017-03-28
+|[hannahgdubin](profiles/hannahgdubin.md)| 2017-01-01 | 2017-03-31
+|[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-03-25
+|[Chris-Boe](profiles/Chris-Boe.md)| 2017-02-26 | 2017-03-22
+|[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 | 2017-03-24
 |[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 |
 |[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
 |[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -15,12 +15,12 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 |
 |[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 |
 |[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 |
-|[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 |
-|[praneetharra](profiles/praneetharra.md)| 2017-04-21 |
-|[shahswet](profiles/shahswet.md)| 2017-05-01 |
-|[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 |
-|[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 |
-|[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 |
+|[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17
+|[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19
+|[shahswet](profiles/shahswet.md)| 2017-05-01 | 2017-05-03
+|[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 | 2017-08-24
+|[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 | 2017-07-31
+|[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 | 2017-07-12
 |[duongdo27](profiles/duongdo.md)| 2017-05-12 | 2017-08-12
 |[aurinsomnia](profiles/aurinsomnia.md)| 2017-05-25 | 2017-08-02
 |[kanishk1010](profiles/kanishk1010.md)| 2017-06-10 | 2017-07-18

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -12,7 +12,7 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[hannahgdubin](profiles/hannahgdubin.md)| 2017-01-01 | 2017-03-31
 |[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-03-25
 |[Chris-Boe](profiles/Chris-Boe.md)| 2017-02-26 | 2017-03-22
-|[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 | 2017-03-24
+|[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 | **2017-03-24**
 |[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 |
 |[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
 |[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -1,4 +1,4 @@
-# Members
+﻿# Members
 
 ## Active Members
 
@@ -36,7 +36,7 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[sahityaLMaruvada](profiles/sahityaLMaruvada.md)| 2017-08-14 |
 |[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 |
 |[thesiege208](profiles/thesiege208.md)| 2017-10-16 |
-|[aas919](profiles/aas919.md)| 2017-10-23 |
+|[aas919](profiles/aas919.md)| 2017-10-23 |2018-02-10
 |[mappuji](profiles/mappuji.md) (**Intern Lead**)| 2017-01-22 |2017-05-29 |
 |[𝖂𝖆𝖗𝖞𝖍𝖊𝖗𝖒𝖎𝖙](profiles/waryhermit.md) (**Intern Lead**)| 2016-12-13 | 2017-04-28 |
 |[FanisGk](profiles/FanisGk.md)| 2016-08-01 | 2017-01-31 |

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -8,20 +8,20 @@ To view the list of current members, go to [active members page](vi-team.md).
 
 |**Username**|**Join Date**|**Leave Date**|
 |------------|-------------|--------------|
-|[hikaruit15](profiles/hikaruit15.md)| 2016-11-17 | 2017-03-28
-|[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-08-31
-|[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 | 2018-01-31
-|[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
-|[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19
-|[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 | 2017-08-24
-|[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 | 2017-07-31
-|[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 | 2017-11-30
-|[duongdo27](profiles/duongdo.md)| 2017-05-12 | 2017-08-12
-|[prajwalajayaprakash](profiles/prajwalajayaprakash.md)| 2017-06-30 | 2017-08-09
-|[daisywatson](profiles/daisywatson.md)| 2017-07-12 | 2017-09-20
-|[alexkarasik](profiles/alexkarasik.md)| 2017-07-17 | 2017-08-22
-|[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 | 2017-11-07
-|[thesiege208](profiles/thesiege208.md)| 2017-10-16 | 2018-01-03 
+|[hikaruit15](profiles/hikaruit15.md)| 2016-11-17 | 2017-03-28 |
+|[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-08-31 |
+|[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 | 2018-01-31 |
+|[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24 |
+|[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19 |
+|[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 | 2017-08-24 |
+|[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 | 2017-07-31 |
+|[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 | 2017-11-30 |
+|[duongdo27](profiles/duongdo.md)| 2017-05-12 | 2017-08-12 |
+|[prajwalajayaprakash](profiles/prajwalajayaprakash.md)| 2017-06-30 | 2017-08-09 |
+|[daisywatson](profiles/daisywatson.md)| 2017-07-12 | 2017-09-20 |
+|[alexkarasik](profiles/alexkarasik.md)| 2017-07-17 | 2017-08-22 |
+|[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 | 2017-11-07 |
+|[thesiege208](profiles/thesiege208.md)| 2017-10-16 | 2018-01-03 |
 |[mappuji](profiles/mappuji.md) (**Intern Lead**)| 2017-01-22 |2017-05-29 |
 |[𝖂𝖆𝖗𝖞𝖍𝖊𝖗𝖒𝖎𝖙](profiles/waryhermit.md) (**Intern Lead**)| 2016-12-13 | 2017-04-28 |
 |[FanisGk](profiles/FanisGk.md)| 2016-08-01 | 2017-01-31 |

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -10,27 +10,16 @@ To view the list of current members, go to [active members page](vi-team.md).
 |------------|-------------|--------------|
 |[hikaruit15](profiles/hikaruit15.md)| 2016-11-17 | 2017-03-28
 |[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-08-31
-|[Chris-Boe](profiles/Chris-Boe.md)| 2017-02-26 | 2017-03-22
-|[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 | **2017-03-24**
 |[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 | 2018-01-31
 |[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
-|[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17
 |[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19
 |[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 | 2017-08-24
 |[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 | 2017-07-31
 |[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 | 2017-11-30
 |[duongdo27](profiles/duongdo.md)| 2017-05-12 | 2017-08-12
-|[kanishk1010](profiles/kanishk1010.md)| 2017-06-10 | 2017-07-18
-|[ChenjieZhou](profiles/ChenjieZhou.md)| 2017-06-10 | 2017-06-12
-|[adhikara](profiles/adhikara.md)| 2017-06-16 | 2017-06-18
-|[sagun98](profiles/sagun98.md)| 2017-06-22 | 2017-07-22
-|[NavneetKarnam](profiles/navneetkarnam.md)| 2017-06-26 | 2017-07-19
-|[tjyothsna16](profiles/tjyothsna16.md)| 2017-06-27 | 2017-07-07
 |[prajwalajayaprakash](profiles/prajwalajayaprakash.md)| 2017-06-30 | 2017-08-09
 |[daisywatson](profiles/daisywatson.md)| 2017-07-12 | 2017-09-20
 |[alexkarasik](profiles/alexkarasik.md)| 2017-07-17 | 2017-08-22
-|[l0rd3141](profiles/l0rd3141.md)| 2017-08-01 | **2017-08-01**
-|[sahityaLMaruvada](profiles/sahityaLMaruvada.md)| 2017-08-14 | **2017-08-17**
 |[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 | 2017-11-07
 |[thesiege208](profiles/thesiege208.md)| 2017-10-16 | 2018-01-03 
 |[mappuji](profiles/mappuji.md) (**Intern Lead**)| 2017-01-22 |2017-05-29 |
@@ -49,6 +38,4 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[sthak004](profiles/sthak004.md)| 2016-06-29 | 2016-07-14 |
 |[Neha1990](profiles/Neha1990.md)| 2016-07-12 | 2016-09-26 |
 |[cw-lin](profiles/cw-lin.md)| 2016-07-22 | 2016-09-14 |
-|[epistulae](profiles/epistulae.md)| 2016-06-01 | 2016-07-01 |
 |[pranesh-s](profiles/pranesh-s.md)| 2016-05-25 | 2016-09-05 |
-|[314159265359](profiles/314159265359.md)| 2016-05-23 | 2016-06-03 |

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -13,7 +13,7 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-03-25
 |[Chris-Boe](profiles/Chris-Boe.md)| 2017-02-26 | 2017-03-22
 |[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 | **2017-03-24**
-|[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 |
+|[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 | 2017-08-22
 |[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
 |[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17
 |[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -1,4 +1,4 @@
-﻿# Members
+# Members
 
 ## Active Members
 
@@ -9,20 +9,18 @@ To view the list of current members, go to [active members page](vi-team.md).
 |**Username**|**Join Date**|**Leave Date**|
 |------------|-------------|--------------|
 |[hikaruit15](profiles/hikaruit15.md)| 2016-11-17 | 2017-03-28
-|[hannahgdubin](profiles/hannahgdubin.md)| 2017-01-01 | 2017-03-31
-|[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-03-25
+|[sarvanivadali](profiles/sarvanivadali.md)| 2017-02-23 | 2017-08-31
 |[Chris-Boe](profiles/Chris-Boe.md)| 2017-02-26 | 2017-03-22
 |[blakedelee](profiles/BlakeDeLee.md)| 2017-03-22 | **2017-03-24**
-|[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 | 2017-08-22
+|[Loshma93](profiles/Loshma93.md) (**Wiki Intern Lead**)| 2017-03-31 | 2018-01-31
 |[zeivhann](profiles/zeivhann.md) (**Mobile Intern Lead**)| 2017-04-01 | 2017-07-24
 |[Supriyaranjan](profiles/Supriyaranjan.md)| 2017-04-04 | 2017-05-17
 |[praneetharra](profiles/praneetharra.md)| 2017-04-21 | 2017-06-19
 |[shahswet](profiles/shahswet.md)| 2017-05-01 | 2017-05-03
 |[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 | 2017-08-24
 |[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 | 2017-07-31
-|[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 | 2017-07-12
+|[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 | 2017-11-30
 |[duongdo27](profiles/duongdo.md)| 2017-05-12 | 2017-08-12
-|[aurinsomnia](profiles/aurinsomnia.md)| 2017-05-25 | 2017-08-02
 |[kanishk1010](profiles/kanishk1010.md)| 2017-06-10 | 2017-07-18
 |[ChenjieZhou](profiles/ChenjieZhou.md)| 2017-06-10 | 2017-06-12
 |[adhikara](profiles/adhikara.md)| 2017-06-16 | 2017-06-18
@@ -36,7 +34,6 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[sahityaLMaruvada](profiles/sahityaLMaruvada.md)| 2017-08-14 | **2017-08-17**
 |[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 | 2017-11-07
 |[thesiege208](profiles/thesiege208.md)| 2017-10-16 | 2018-01-03 
-|[aas919](profiles/aas919.md)| 2017-10-23 |2018-02-10
 |[mappuji](profiles/mappuji.md) (**Intern Lead**)| 2017-01-22 |2017-05-29 |
 |[𝖂𝖆𝖗𝖞𝖍𝖊𝖗𝖒𝖎𝖙](profiles/waryhermit.md) (**Intern Lead**)| 2016-12-13 | 2017-04-28 |
 |[FanisGk](profiles/FanisGk.md)| 2016-08-01 | 2017-01-31 |

--- a/pages/vi/vi-former-members.md
+++ b/pages/vi/vi-former-members.md
@@ -21,19 +21,19 @@ To view the list of current members, go to [active members page](vi-team.md).
 |[Yurockkk](profiles/Yurockkk.md)| 2017-05-05 |
 |[sarah-lu102](profiles/sarah-lu102.md) (**Wiki Intern Lead**)| 2017-05-10 |
 |[snazzybunny](profiles/snazzybunny.md) (**Embedded Systems Lead**)| 2017-05-11 |
-|[duongdo27](profiles/duongdo.md)| 2017-05-12 |
-|[aurinsomnia](profiles/aurinsomnia.md)| 2017-05-25 |
-|[kanishk1010](profiles/kanishk1010.md)| 2017-06-10 |
-|[ChenjieZhou](profiles/ChenjieZhou.md)| 2017-06-10 |
-|[adhikara](profiles/adhikara.md)| 2017-06-16 |
+|[duongdo27](profiles/duongdo.md)| 2017-05-12 | 2017-08-12
+|[aurinsomnia](profiles/aurinsomnia.md)| 2017-05-25 | 2017-08-02
+|[kanishk1010](profiles/kanishk1010.md)| 2017-06-10 | 2017-07-18
+|[ChenjieZhou](profiles/ChenjieZhou.md)| 2017-06-10 | 2017-06-12
+|[adhikara](profiles/adhikara.md)| 2017-06-16 | 2017-06-18
 |[sagun98](profiles/sagun98.md)| 2017-06-22 | 2017-07-22
 |[NavneetKarnam](profiles/navneetkarnam.md)| 2017-06-26 | 2017-07-19
 |[tjyothsna16](profiles/tjyothsna16.md)| 2017-06-27 | 2017-07-07
 |[prajwalajayaprakash](profiles/prajwalajayaprakash.md)| 2017-06-30 | 2017-08-09
-|[daisywatson](profiles/daisywatson.md)| 2017-07-12 | *2017-07-20*
+|[daisywatson](profiles/daisywatson.md)| 2017-07-12 | 2017-09-20
 |[alexkarasik](profiles/alexkarasik.md)| 2017-07-17 | 2017-08-22
-|[l0rd3141](profiles/l0rd3141.md)| 2017-08-01 | *2017-08-01*
-|[sahityaLMaruvada](profiles/sahityaLMaruvada.md)| 2017-08-14 | *2017-08-17*
+|[l0rd3141](profiles/l0rd3141.md)| 2017-08-01 | **2017-08-01**
+|[sahityaLMaruvada](profiles/sahityaLMaruvada.md)| 2017-08-14 | **2017-08-17**
 |[ajGingrich](profiles/ajGingrich.md)| 2017-09-11 | 2017-11-07
 |[thesiege208](profiles/thesiege208.md)| 2017-10-16 | 2018-01-03 
 |[aas919](profiles/aas919.md)| 2017-10-23 |2018-02-10


### PR DESCRIPTION
### Fixes #1657 

### Description
I have completed the leave dates for the former members' list. Some of the dates do not look accurate - I have highlighted them in bold lettering. One member was not found on GitHub.

Once the dates are good, I can sort them in chronological order either by joining dates or leaving dates.

### RawGit preview link
https://rawgit.com/aakarnik/aakarnik.github.io/Fix_former_members/#!pages/vi/vi-former-members.md
