### PR TITLE
Fix typo on github markdown (fixes #1745)

### DIFF
--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -113,7 +113,7 @@ Now, check what this looks like on your own page `https://rawgit.com/YourUserNam
 
 ### Open a pull request
 
-Once you have your profile ready, it's time to create a pull request. Clink on one of the "Pull request" button as highlighted in the screenshot below.
+Once you have your profile ready, it's time to create a pull request. Click on one of the "Pull request" button as highlighted in the screenshot below.
 
 ![Initiate Pull Request](images/vi-initiate-pull-request.png)
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes # 1745

### Description
Typo on  github markdown tutorial under heading "Open a Pull Request". Typo corrected "Clink" -> "Click"

### RawGit preview link
<!-- rawgit link to page(s) changed -->
https://rawgit.com/rhuturajm/rhuturajm.github.io/typo_issues/#!pages/vi/vi-github-and-markdown.md