### PR TITLE
Fix techgenius tables (fixes #1761)

### DIFF
--- a/pages/techgenius/tg-team.md
+++ b/pages/techgenius/tg-team.md
@@ -4,7 +4,6 @@
 
 |**Username**|**Join Date**|
 |------------|-------------|
-|**➤ Tech Geniuses**||
 |[MadagascarOLE](../vi/profiles/MadagascarOLE.md)|2017-10-13|
 |[cramartef](../vi/profiles/cramartef.md)|2017-10-12|
 
@@ -12,3 +11,5 @@
 
 |**Username**|**Join Date**|**Leave Date**|
 |------------|-------------|--------------|
+|[MadagascarOLE](../vi/profiles/MadagascarOLE.md)|2017-10-13|N/A|
+|[cramartef](../vi/profiles/cramartef.md)|2017-10-12|N/A|


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #1761 

This commit removes the unnecessary label and adds members to the tech genius
to the table.

### Description

Currently there's a redundant label and missing information in the techgenius
team page. We know that this is the techgenius page, so it doesn't need to be
listed in the table. Additionally the tech geniuses table at the bottom
of the page is empty, while the current members section is populated, which
makes no sense.

### RawGit preview link
<!-- rawgit link to page(s) changed -->
https://rawgit.com/gcantieni/gcantieni.github.io/fix-techgenius-team/#!pages/techgenius/tg-team.md
