### PR TITLE
Changed Wording For First Steps - Step 8 (issue #1942)

### DIFF
--- a/pages/vi/vi-first-steps.md
+++ b/pages/vi/vi-first-steps.md
@@ -88,7 +88,7 @@ Just as your learning with this Wiki was made possible by the efforts of previou
 
 - Once you complete Step 8, you should have:
    * 5 merged pull requests (one at step 3, one at step 6 and three at step 8)
-   * 4 comments made (on issues you didn't create, one at step 6 and three at step 8)
+   * 4 comments made on *issues you didn't create* (one at step 6 and three at step 8)
    * 4 issues created (one at step 6 and three at step 8)
 
 **NOTE**: You can track your progress with the number of pull requests and issues [here](vi-track-progress.md).


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #1942 

### Description
Changed the wording in Virtual Intern First Steps - Step 8

From: 

> - Once you complete Step 8, you should have:
 >   - 5 merged pull requests (one at step 3, one at step 6 and three at step 8)
 >   - 4 comments made (on issues you didn't create, one at step 6 and three at step 8)
 >   - 4 issues created (one at step 6 and three at step 8)

To:

> - Once you complete Step 8, you should have:
 >   - 5 merged pull requests (one at step 3, one at step 6 and three at step 8)
 >   - 4 comments made *on issues you didn't create* (one at step 6 and three at step 8)
 >   - 4 issues created (one at step 6 and three at step 8)

to make it easier to understand as it follows the overall pattern.

### RawGit preview link
<!-- rawgit link to page(s) changed -->
https://rawgit.com/Sriharsha-Singam/Sriharsha-Singam-ole.github.io/first-steps-8-better-wording-issue1942/#!pages/vi/vi-first-steps.md