### PR TITLE
Adding Reference to commit message style guide (fixes #1959)

### DIFF
--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -52,7 +52,7 @@ After making modifications to your local files and before making a commit, you w
 
 ## Create a Commit
 
-After you are done making your changes, use the `git status` command to see which files in the working directory have been modified. If you wish to stage all of the modified files shown, use the `git add .` (The '.' is part of the command.) command. Otherwise you can choose only the file or files you wish to stage by using the `git add <file1> <file2> <file3>...` command. Now that you have selected the files you wish to include, use the commands `git commit -m "commit message"` and `git push -u origin name_of_your_new_branch` to save your changes and push them to your Github (for any further commit on the same branch after the first one, you can just use `git push`).
+After you are done making your changes, use the `git status` command to see which files in the working directory have been modified. If you wish to stage all of the modified files shown, use the `git add .` (The '.' is part of the command.) command. Otherwise you can choose only the file or files you wish to stage by using the `git add <file1> <file2> <file3>...` command. Now that you have selected the files you wish to include, use the commands `git commit -m "commit message"` (refer the commit message guidelines below) and `git push -u origin name_of_your_new_branch` to save your changes and push them to your Github (for any further commit on the same branch after the first one, you can just use `git push`).
 
 ### Commit Message Style Guide
 

--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -52,7 +52,7 @@ After making modifications to your local files and before making a commit, you w
 
 ## Create a Commit
 
-After you are done making your changes, use the `git status` command to see which files in the working directory have been modified. If you wish to stage all of the modified files shown, use the `git add .` (The '.' is part of the command.) command. Otherwise you can choose only the file or files you wish to stage by using the `git add <file1> <file2> <file3>...` command. Now that you have selected the files you wish to include, use the commands `git commit -m "commit message"` (refer the commit message guidelines below) and `git push -u origin name_of_your_new_branch` to save your changes and push them to your Github (for any further commit on the same branch after the first one, you can just use `git push`).
+After you are done making your changes, use the `git status` command to see which files in the working directory have been modified. If you wish to stage all of the modified files shown, use the `git add .` (The '.' is part of the command.) command. Otherwise you can choose only the file or files you wish to stage by using the `git add <file1> <file2> <file3>...` command. Now that you have selected the files you wish to include, use the commands `git commit -m "commit message"` (refer to the commit message guidelines below) and `git push -u origin name_of_your_new_branch` to save your changes and push them to your Github (for any further commit on the same branch after the first one, you can just use `git push`).
 
 ### Commit Message Style Guide
 


### PR DESCRIPTION

<!-- issue number this pull request resolves -->
Fixes #1959

### Description

Added a reference "(refer to the commit message guidelines below)" to the commit message guidelines for the GitHub Issues step-6 

### RawGit preview link
<!-- rawgit link to page(s) changed -->
https://rawgit.com/BhargaviNadendla/BhargaviNadendla.github.io/AddingReference/#!pages/vi/vi-github-issues.md