### PR TITLE
Add target=_blank to github link (fixes #1987)

### DIFF
--- a/pages/vi/vi-first-steps.md
+++ b/pages/vi/vi-first-steps.md
@@ -28,7 +28,7 @@ There is no official deadline to complete these steps, but most candidates who a
 
 1. Send us your resume again along with a short description of yourself and what you would like to be called to [vi+resume@ole.org](mailto:vi+resume@ole.org).
 
-2. Create a [GitHub account](https://github.com/) then watch [Open Learning Exchange's github.io repo](https://github.com/open-learning-exchange/open-learning-exchange.github.io) and Follow [Leonard](https://github.com/leomaxi) and [Dogi](https://github.com/dogi) on GitHub. In GitHub, we "Watch" organization repositories and "Follow" individuals. Look for the "Watch" button at the top right of the page when you are in a repository.  Also, follow each other to see what others in the group are doing. (Click on the image to enlarge.)
+2. Create a [GitHub account](https://github.com/) then watch <a href="https://github.com/open-learning-exchange/open-learning-exchange.github.io" target="_blank">Open Learning Exchange's github.io repo</a> and Follow [Leonard](https://github.com/leomaxi) and [Dogi](https://github.com/dogi) on GitHub. In GitHub, we "Watch" organization repositories and "Follow" individuals. Look for the "Watch" button at the top right of the page when you are in a repository.  Also, follow each other to see what others in the group are doing. (Click on the image to enlarge.)
 
   ![Watch Screen Shot](images/vi-watch.png)
   ![Follow Screen Shot](images/vi-follow.png)


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #1987 

### Description
I couldn't figure out why only this link wasn't generating a "_blank" tag, so I manually wrote it in with HTML.

I noticed that when running locally, the "_blank" tag is generated with Markdown, but in production, it is not... However, all other external links seem to be working fine, and have automatically generated a _blank tag.

### RawGit preview link
[Rawgit Link](https://rawgit.com/jimkosh/jimkosh.github.io/add_blank_tag_to_github_link/#!pages/vi/vi-first-steps.md)