### PR TITLE
Add Gitter links for screenshots (fixes #2032)

### DIFF
--- a/pages/vi/vi-configurations.md
+++ b/pages/vi/vi-configurations.md
@@ -55,7 +55,7 @@ Then, click on the **"Register"** button. Your registration request for your com
 
 After clicking on the OK button, you will be automatically logged in.
 
-Then, post to the Gitter chat the screenshot you took earlier.
+Then, post to the [Gitter chat](https://gitter.im/open-learning-exchange/chat) the screenshot you took earlier.
 
 ## Troubleshooting
 

--- a/pages/vi/vi-configurations.md
+++ b/pages/vi/vi-configurations.md
@@ -43,7 +43,7 @@ You will be shown the page below. Make sure you fill it out completely.
 
 ![Become an Administrator](images/vi-become-admin.png)
 
-Next, fill out the configurations. Your name and code must be the same and should match your Github name so we can easily locate your community in Virtual Intern Nation. Write your `name` in lowercase and `code` in uppercase, and pick **Virtual Intern Nation (vi)** for nation as in the example below. **After filling out your configurations, remember to save a screenshot of the configuration page so that you can post it on the Gitter chat after submitting your registration request.**
+Next, fill out the configurations. Your name and code must be the same and should match your Github name so we can easily locate your community in Virtual Intern Nation. Write your `name` in lowercase and `code` in uppercase, and pick **Virtual Intern Nation (vi)** for nation as in the example below. **After filling out your configurations, remember to save a screenshot of the configuration page so that you can post it on the [Gitter chat](https://gitter.im/open-learning-exchange/chat) after submitting your registration request.**
 
 ![Configurations](images/vi-configuration.png)
 

--- a/pages/vi/vi-planet-installation-and-configuration.md
+++ b/pages/vi/vi-planet-installation-and-configuration.md
@@ -150,11 +150,11 @@ You will be asked to:
     - Use your GitHub username as `Name` so we can locate you on Virtual Intern nation. (`Name` must be unique on the nation side, if you have configured `planet` using your GitHub username before, please add a letter or digits to the end of your original username.)
     - `Code` is not editable and it will be automatically filled
 - Fill out contact details
-- Click `Submit` and let us know in the Gitter chat <!-- so we can accept your community registration on VI Nation -->
+- Click `Submit` and let us know in the [Gitter chat](https://gitter.im/open-learning-exchange/chat) <!-- so we can accept your community registration on VI Nation -->
 
 ![Planet Community Configuration](images/vi-planet-configuration.png)
 
-After logging in, please explore around and post a screenshot of your `planet` to the Gitter chat.
+After logging in, please explore around and post a screenshot of your `planet` to the [Gitter chat](https://gitter.im/open-learning-exchange/chat).
 
 ![Planet UI Screenshot](images/vi-planet-ui-screenshot.png)
 


### PR DESCRIPTION
Fixes #2032 

### Description
Added three links to Gitter chat where the user either needs to post screenshots or notify about the current progress of installing and configuring Planet and Bell.

### RawGit preview link
https://rawgit.com/svlesiv/svlesiv.github.io/screenshot_gitter_links_branch/#!pages/vi/vi-configurations.md
https://rawgit.com/svlesiv/svlesiv.github.io/screenshot_gitter_links_branch/#!pages/vi/vi-planet-installation-and-configuration.md
