### PR TITLE
Added note about possibly needing to check NDIS5 driver support when installing Docker on Windows issue #2072

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/pages/vi/vi-planet-installation-and-configuration.md
+++ b/pages/vi/vi-planet-installation-and-configuration.md
@@ -24,7 +24,7 @@ In order to run `planet`, you will need Docker Community Edition installed.
   - Follow the official [Install Docker for Windows](https://docs.docker.com/docker-for-windows/install/) guide
   - [Chocolatey](https://chocolatey.org/) – the package manager for Windows was installed to your machine in the previous step. Please read [What to know before you install
 ](https://docs.docker.com/docker-for-windows/install/#what-to-know-before-you-install) and run `choco install docker-for-windows`
-- If you do not have Windows version specified above, you will need to install [Docker Toolbox](https://docs.docker.com/toolbox/overview/). Please follow the official guide [Install Docker Toolbox on Windows](https://docs.docker.com/toolbox/toolbox_install_windows/).
+- If you do not have Windows version specified above, you will need to install [Docker Toolbox](https://docs.docker.com/toolbox/overview/). Please follow the official guide [Install Docker Toolbox on Windows](https://docs.docker.com/toolbox/toolbox_install_windows/). *NOTE: You may need to check the "Install VirtualBox with NDIS5 driver" option when it asks to install VirtualBox.*
 
 ### macOS
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2072 

### Description
Some users encounter an  error upon first loading Docker. This suggests users may need to check the option to install NDIS5 driver support for VirtualBox when installing Docker. 

### RawGit preview link
Not supported for me. RawGit not available. 
