### PR TITLE
Clarifies Community Planet installation by fixing formatting in Step 2.1 (Fixes #2111)

### DIFF
--- a/pages/vi/vi-planet-installation-vagrant.md
+++ b/pages/vi/vi-planet-installation-vagrant.md
@@ -84,7 +84,9 @@ sudo dpkg -i vagrant.deb
 sudo apt-get install -f
 ```
 
-### Install a Community Planet
+---
+
+## Install a Community Planet
 
 Make sure you `cd` to the designated OLE directory you created earlier.
 

--- a/pages/vi/vi-planet-installation-vagrant.md
+++ b/pages/vi/vi-planet-installation-vagrant.md
@@ -86,7 +86,7 @@ sudo apt-get install -f
 
 ---
 
-## Install a Community Planet
+## Install a Community Planet  
 
 Make sure you `cd` to the designated OLE directory you created earlier.
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
#2111 

### Description
In [Step 1.1](http://open-learning-exchange.github.io/#!./pages/vi/vi-planet-installation-vagrant.md) of [First Steps](http://open-learning-exchange.github.io/#!pages/vi/vi-first-steps.md), the **Install a Community Planet** section is a subsection under the **macOS or Ubuntu** section, which can make it confusing for Windows users.  This problem is resolved by isolating **Install a Community Planet** in its own section. 

### RawGit preview link
<!-- rawgit link to page(s) changed -->
https://raw.githack.com/jazdao/jazdao.github.io/wrong-section/#!pages/vi/vi-planet-installation-vagrant.md