### PR TITLE
Fix typo in Github and Markdown page (fixes #2213)

### DIFF
--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -38,7 +38,7 @@ Below is a summary of the steps that we will walk you through:
 * [Login to GitHub with your username and password](#Login_to_GitHub_with_your_username_and_password)
 * [Find and fork the correct repository](#Find_and_fork_the_correct_repository)
 * [Go to Settings and rename your repository](#Go_to_Settings_and_rename_your_repository)
-* [Check if you github.io works](#Check_if_you_github.io_works)
+* [Check if your github.io works](#Check_if_you_github.io_works)
 * [Create a new file as your personal MDwiki page and commit your changes](#Create_a_new_file_as_your_personal_MDwiki_page_and_commit_your_changes)
 * [Open a pull request](#Open_a_pull_request)
 


### PR DESCRIPTION
Fixes #2213 

### Description

Fixes a simple typo in the [Github and Markdown](http://open-learning-exchange.github.io/#!./pages/vi/vi-github-and-markdown.md) page. Changes the word *you* to *your*.

### Screenshot

<img width="485" alt="Screen Shot 2019-03-15 at 7 39 52 PM" src="https://user-images.githubusercontent.com/29234807/54467241-3d256380-475a-11e9-912c-2bd49d4a8e2d.png">


### RawGit preview link
https://raw.githack.com/zelmi/zelmi.github.io/typo_you/#!./pages/vi/vi-github-and-markdown.md
