### PR TITLE
Fix link that leads to wrong page (fixes #2218)

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,1 +1,1 @@
-Sorry, the page you are looking for doesn't exist.  [Go home](#!index.md)
+Sorry, the page you are looking for doesn't exist. [Go home](http://open-learning-exchange.github.io/#!index.md)


### PR DESCRIPTION
Fixes #2218

### Description

There is a link in the **404.md** page that should lead a user to to [OLE's home page](http://open-learning-exchange.github.io/#!index.md), but instead it leads to another 404 page. This pull request fixes the link so that a user is sent to [OLE's home page](http://open-learning-exchange.github.io/#!index.md) after clicking it.

<img width="1440" alt="Screen Shot 2019-03-22 at 4 42 44 PM" src="https://user-images.githubusercontent.com/29234807/54886263-9a0cd200-4e5c-11e9-842d-94282465d4eb.png">

An example of how the 404 page can be accessed is by going to either the [Github and Markdown](https://raw.githack.com/zelmi/zelmi.github.io/goHome_link/#!./pages/vi/vi-github-and-markdown.md) page or [Git Repositories](https://raw.githack.com/zelmi/zelmi.github.io/goHome_link/#!./pages/vi/vi-github-and-repositories.md) page and opening any of the **Start Here** links in a new tab.

### RawGit preview link

- [Github and Markdown](https://raw.githack.com/zelmi/zelmi.github.io/goHome_link/#!./pages/vi/vi-github-and-markdown.md)

- [Git Repositories](https://raw.githack.com/zelmi/zelmi.github.io/goHome_link/#!./pages/vi/vi-github-and-repositories.md)

