### PR TITLE
Typo in the port number

### DIFF
--- a/pages/vi/vi-configurations-vagrant.md
+++ b/pages/vi/vi-configurations-vagrant.md
@@ -24,7 +24,7 @@ The Planet is not only a library, but also an individualized learning system, wh
 
 ## macOS and Ubuntu
 
-Check that your vagrant is up and running with `vagrant global-status`. Assuming that it's running or you launch it using `vagrant up prod`, open browser. Go to http://localhost:3100. Make sure to have the correct port number (3000), otherwise it will not work correctly.
+Check that your vagrant is up and running with `vagrant global-status`. Assuming that it's running or you launch it using `vagrant up prod`, open browser. Go to http://localhost:3100. Make sure to have the correct port number (3100), otherwise it will not work correctly.
 
 ## Windows
 


### PR DESCRIPTION
Fixes #2254 

### Description
Small typo in the port number in macOS and Ubuntu (previous: 3000; corrected: 3100)

### RawGit preview link
https://raw.githack.com/nachiketdhamankar/nachiket-ole.github.io/patch-1/#!pages/vi/vi-configurations-vagrant.md