### PR TITLE
Changed Sync with Nation to Manage Sync (fixes #2259)

### DIFF
--- a/pages/vi/vi-nation.md
+++ b/pages/vi/vi-nation.md
@@ -26,7 +26,7 @@ You can click on "Manager" icon as you can see on the picture below.
 
 ![Clicking on "Manager"](images/edit-vi-nation-manager.png "Dashboard in your localhost")
 
-Next, click on "Sync with Nation".
+Next, click on "Manage Sync".
 
 ![Clicking on "Sync with Nation"](images/vi-nation-sync.png "Community Manage Page in your localhost")
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes # 2259

### Description
In Sync With the Nation the second step says click on "Sync with Nation" which is not represented in the picture or when virtual interns go through the actual step.

![issue 2259](https://user-images.githubusercontent.com/22855384/56773706-efead780-6784-11e9-91c1-c1b2a83205aa.png)

I changed "Sync with Nation" to "Manager Sync"

### RawGit preview link
<https://raw.githack.com/Kid243/Kid243.github.io/SyncwithNation2ManageSync/#!./pages/vi/vi-nation.md>
