### PR TITLE
added additional recognized problem in troubleshooting section (Issue #2327)

### DIFF
--- a/pages/vi/vi-configurations-vagrant.md
+++ b/pages/vi/vi-configurations-vagrant.md
@@ -67,9 +67,9 @@ Then, post to the [Gitter chat](https://gitter.im/open-learning-exchange/chat) t
 
 4. There is a chance upon having your account approved that the website does not recognize you as registered. You will be stuck infinitely loading and upon refresh, the page will be blank.
 
-![Screenshot (3)](https://user-images.githubusercontent.com/22685147/58672048-259a5780-8313-11e9-8146-6d419e83537e.png)
+![Not recognized](https://user-images.githubusercontent.com/22685147/58755806-bb6fe700-84b9-11e9-8a27-d3e3ab56ffba.png)
 
-![Screenshot (4)](https://user-images.githubusercontent.com/22685147/58672123-7611b500-8313-11e9-843f-d54932d684c3.png)
+![Blank](https://user-images.githubusercontent.com/22685147/58755807-be6ad780-84b9-11e9-86b5-c745f584ac41.png)
 
 In order to fix this problem, simply follow the procedures stated above in bullet 3: use `vagrant destroy prod`, then `vagrant up prod`. Afterwards, use a slightly different name for your configuration, take a screenshot of the new configuration page, and post it to the [Gitter chat](https://gitter.im/open-learning-exchange/chat).
 

--- a/pages/vi/vi-configurations-vagrant.md
+++ b/pages/vi/vi-configurations-vagrant.md
@@ -1,4 +1,4 @@
-# Planet Configurations
+﻿# Planet Configurations
 
 ## Objectives
 
@@ -64,6 +64,14 @@ Then, post to the [Gitter chat](https://gitter.im/open-learning-exchange/chat) t
 2. If you accidentally delete your Planet admin account, creating a new learner account on the login page will cause problems in later steps. The best way to solve this problem is to start over and create a new community using `vagrant destroy prod` and then `vagrant up prod` in `planet` folder.
 
 3. In the case that you use the command `vagrant destroy prod`, your community Planet would be wiped together with the virtual machine, but  community registration would still exist on the nation side. After rebuilding your community Planet using `vagrant up prod`, fill out the configurations again with a slightly different Name (e.g. adding a number or letter to the end of your original GitHub username) so that we can still locate your community on the Nation side. Also, remember to take a screenshot of the new configuration page and post it to the [Gitter chat](https://gitter.im/open-learning-exchange/chat).
+
+4. There is a chance upon having your account approved that the website does not recognize you as registered. You will be stuck infinitely loading and upon refresh, the page will be blank.
+
+![Screenshot (3)](https://user-images.githubusercontent.com/22685147/58672048-259a5780-8313-11e9-8146-6d419e83537e.png)
+
+![Screenshot (4)](https://user-images.githubusercontent.com/22685147/58672123-7611b500-8313-11e9-843f-d54932d684c3.png)
+
+In order to fix this problem, simply follow the procedures stated above in bullet 3: use `vagrant destroy prod`, then `vagrant up prod`. Afterwards, use a slightly different name for your configuration, take a screenshot of the new configuration page, and post it to the [Gitter chat](https://gitter.im/open-learning-exchange/chat).
 
 ## Next Section **→**
 


### PR DESCRIPTION
Fixes #2327

### Description
Sometimes upon registering an account as specified on the Planet Configurations page and having it approved, it will afterwards say that the user is not registered, and the site will break permanently upon refresh. This is fixed upon recreating the account through "vagrant destroy prod" and "vagrant up prod" but this is not under the problems listed under Troubleshooting.

[x] Check for issue number in pull request title
[x] Are there any unneeded files in the pull request?
[x] Did they make a branch for their patch?
[x] Does the pull request actually fix the issue?
[x] Check the pull request on raw.githack, does it display without any errors?
[x] Is there any merge conflicts?
[x] Make sure that people use their GitHub accounts when making commits through git

[Raw.Githack preview link](https://raw.githack.com/sjson421/sjson421.github.io/config-troubleshooting-add/#!./pages/vi/vi-configurations-vagrant.md)