### PR TITLE
repeat phrasing removed for first time syncing (Issue #2333)

### DIFF
--- a/pages/vi/vi-planetapps.md
+++ b/pages/vi/vi-planetapps.md
@@ -1,4 +1,4 @@
-# Planet Tutorial
+﻿# Planet Tutorial
 
 ## Objectives
 
@@ -58,7 +58,7 @@ As you can see from the image below, there is an update ready to be downloaded. 
 1. Click the `Upgrade` button on Manager page and it take you to upgrade page. An update refers to a software update which improves the Planet (Note: If you do not see `Upgrade` button then simply carry on). It will then ask you for verification.
 2. After the upgrade is complete, undergo `vagrant halt prod` and `vagrant up prod` to restart planet.
 3. Go back to the Manager page and click on `Fetch Items` and download the courses offered (2nd picture). (**Note:** Fetch Items is only available if nation has sent anything to your community. If you do not see Fetch Items the please carry on.)
-4. Finally, repeat the process of sending an activities sync to the nation using `Manage Sync`.
+4. Finally, send an activities sync to the nation using `Manage Sync`.
 
 **NOTE**:  
 • If there is an "internet connection" error when you click the "Upgrade" button, please repeat the step.  


### PR DESCRIPTION
Fixes #2333

### Description
In Step 4 Planet Tutorial, under "Different Kinds of Updates to Your Community", step 4 mentions that:

>Finally, repeat the process of sending an activities sync to the nation using Manage Sync.

When it is the first time for syncing.

This is now changed to 

>Finally, send an activities sync to the nation using Manage Sync.

[x] Check for issue number in pull request title
[x] Are there any unneeded files in the pull request?
[x] Did they make a branch for their patch?
[x] Does the pull request actually fix the issue?
[x] Check the pull request on raw.githack, does it display without any errors?
[x] Is there any merge conflicts?
[x] Make sure that people use their GitHub accounts when making commits through git

[Raw.Githack preview link](https://raw.githack.com/sjson421/sjson421.github.io/sync-phrasing/#!./pages/vi/vi-planetapps.md)