### PR TITLE
Dummy_account_line_fix (fixes #2451)

### DIFF
--- a/pages/vi/vi-nation.md
+++ b/pages/vi/vi-nation.md
@@ -14,7 +14,7 @@ There should be constant communication between the nation and the communities. W
 
 Make sure vagrant is running and then click [here](http://localhost:3100) to access your Community Planet.
 
-**NOTE**: Before you can sync your community with the nation, you will need to create an additional dummy user on your community. Therefore, create one by clicking on "Become a Member" under the SIGN-IN button. Then fill out the details and press the "Become a Member" button. (Tip: When creating the dummy user, don't put a password that you actually use). Then, login to dummy account you just created and double-check that you're listed under Members on Manager page. Then, log out and log back in with your admin account. Now that your community has a user, you can sync with the nation.
+**NOTE**: Before you can sync your community with the nation, you will need to create an additional dummy user on your community. Therefore, create one by clicking on "Become a Member" under the SIGN-IN button. Then fill out the details and press the "Become a Member" button. (Tip: When creating the dummy user, don't put a password that you actually use). Next, log back in to your admin account and double-check that your dummy account is listed under Members on the Manager page. Now that your community has a user, you can sync with the nation.
 
 ![Clicking on "Dummy User"](images/vi-become-member.png "Dummy User")
 


### PR DESCRIPTION


fixes #2451 

Replaces line advising intern to 'log in to dummy account' with 'log into admin account' 

https://raw.githack.com/irisb1701/irisb1701.github.io/vi_git_issue/#!pages/vi/vi-nation.md
