### PR TITLE
Inconsistency in using dev and prod

### DIFF
--- a/Change.txt
+++ b/Change.txt
@@ -1,0 +1,1 @@
+this is a change

--- a/pages/vi/profiles/275vytran.md
+++ b/pages/vi/profiles/275vytran.md
@@ -6,6 +6,7 @@ Vidor, TX | GMT-5 | Window 7|
 
 ## About Me
 Hi all, I'm a recent computer science graduate. I was born and raised in [Phan Thiet, Vietnam] and came to Beaumont for my graduate study. I have a huge passion on coding and I am glad to be able to join OLE team.
+Nice to meet you all.
 
 ## Contact
 * __LinkedIn:__ [275vytran](https://www.linkedin.com/in/275vytran/)

--- a/pages/vi/vi-vagrant.md
+++ b/pages/vi/vi-vagrant.md
@@ -1,4 +1,4 @@
-# Vagrant Tutorial
+﻿# Vagrant Tutorial
 
 ## Objectives
 
@@ -44,7 +44,7 @@ A lot of Vagrant commands require us to specify a target machine. We can also ru
 ```
 id       name   provider   state   directory
 ---------------------------------------------------------------------------
-219abaa  dev     virtualbox running /Users/aberdean/planet
+219abaa  prod     virtualbox running /Users/aberdean/planet
 
 The above shows information about all known Vagrant environments
 on this machine. This data is cached and may not be completely


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2487

### Description
In Vagrant tutorial, at Global Status, in the box we can see the id is 219abaa and name is dev. However, in the below instruction says "We have a Vagrant virtual machine called prod running in VirtualBox". 
Solution: we can change dev to prod in the grey box. Or, change prod to dev in the instruction.

![Untitled](https://user-images.githubusercontent.com/49819696/60390583-9e6e0a00-9a9f-11e9-8fc2-b9d6c40253c8.png)


### Raw.Githack preview link
https://raw.githack.com/275vytran/275vytran.github.io/275vytran/#!./pages/vi/vi-vagrant.md
<!-- raw.githack link to page(s) changed -->
