### PR TITLE
Add more information when creating dummy account in Step 7 - Nation Planet (Fixes #2496)

### DIFF
--- a/pages/vi/vi-nation.md
+++ b/pages/vi/vi-nation.md
@@ -14,7 +14,7 @@ There should be constant communication between the nation and the communities. W
 
 Make sure vagrant is running and then click [here](http://localhost:3100) to access your Community Planet.
 
-**NOTE**: Before you can sync your community with the nation, you will need to create an additional dummy user on your community. Therefore, create one by clicking on "Become a Member" under the SIGN-IN button. Then fill out the details and press the "Become a Member" button. (Tip: When creating the dummy user, don't put a password that you actually use). Next, log back in to your admin account and double-check that your dummy account is listed under Members on the Manager page. Now that your community has a user, you can sync with the nation.
+**NOTE**: Before you can sync your community with the nation, you will need to create an additional dummy user on your community. Therefore, create one by clicking on "Become a Member" under the SIGN-IN button. Then fill out the details and press the "Become a Member" button. (Tip: When creating the dummy user, don't put a password that you actually use). Next, log back in to your admin account and double-check that your dummy account is listed under Members on the Manager page. Now that your community has a user, you can sync with the nation. If you can not create dummy user, please click on the helpful links and videos under the Useful Links section at the bottom of the Nation Planet page. Once there, scroll up to Q22 for a solution, which is located under the Technical questions section.
 
 ![Clicking on "Dummy User"](images/vi-become-member.png "Dummy User")
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2496 

### Description
In Step 7 Nation Planet, in the NOTE talking about creating dummy user. 
![dsaad](https://user-images.githubusercontent.com/49819696/60390861-64eccd00-9aa6-11e9-89eb-a22634cb585c.png)

There is an error which is can not create dummy user. The error as image below: 
![Untitled (1)](https://user-images.githubusercontent.com/49819696/60390859-3d960000-9aa6-11e9-836b-521d86ce5697.png)

So, in this NOTE, we should detail this case so that learner can easier to solve their problem by themselves. I append solution to NOTE: "If you can not create dummy user, please click on the helpful links and videos under the Useful Links section at the bottom of the Nation Planet page. Once there, scroll up to Q22 for a solution, which is located under the Technical questions section."

### Raw.Githack preview link
https://raw.githack.com/275vytran/275vytran.github.io/branch1/#!pages/vi/vi-nation.md
<!-- raw.githack link to page(s) changed -->
