### PR TITLE
Error when installing Debian for Ubuntu in Step Planet Installation (Fixes #2495)

### DIFF
--- a/pages/vi/vi-planet-installation-vagrant.md
+++ b/pages/vi/vi-planet-installation-vagrant.md
@@ -1,4 +1,4 @@
-# Planet Installation
+﻿# Planet Installation
 
 ## Objectives
 
@@ -86,7 +86,12 @@ wget -O vagrant.deb https://yourcopiedlink.com/vagrant.deb
 sudo dpkg -i vagrant.deb
 sudo apt-get install -f
 ```
+If you encounter the error:
+   > dpkg: error processing archive vagrant.deb (--install): package architecture (amd64) does not match system (i386)
+   > Errors were encountered while processing: vagrant.deb
 
+To solve this problem: Copy link location of Debian 32-bit instead and run commands again.
+ 
 ---
 
 ## Install a Community Planet  


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2495

### Description
In the step Planet Installation, 
![das](https://user-images.githubusercontent.com/49819696/60391019-c2831880-9aaa-11e9-9a15-b85cd91a53f1.png)

There is a problem that learner might encounter when running command "sudo dpkg -i vagrant.deb":
> dpkg: error processing archive vagrant.deb (--install):
>  package architecture (amd64) does not match system (i386)
> Errors were encountered while processing:
>  vagrant.deb

To solve that problem: copy link locattion of Debian 32-bit instead of 64-bit

### Raw.Githack preview link
https://raw.githack.com/275vytran/275vytran.github.io/branch2/#!pages/vi/vi-planet-installation-vagrant.md
<!-- raw.githack link to page(s) changed -->
