### PR TITLE
Link provided is irrelevant to the instruction on Step 6

### DIFF
--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -1,4 +1,4 @@
-# GitHub Issues
+﻿# GitHub Issues
 
 ## Objectives
 
@@ -53,7 +53,7 @@ If you're still confused, that's quite alright. [Forking Workflow](https://www.a
 
 ### Preview Changes Locally
 
-After making modifications to your local files and before making a commit, you would want to preview the changes locally. The following link, [how to preview changes](http://dynalon.github.io/mdwiki/#!faq.md), gives all the information about how to preview changes from your machine. There's also another option to preview using online environment. This [link](https://dillinger.io/) takes you to the online environment.
+After making modifications to your local files and before making a commit, you would want to preview the changes locally. The following link, [how to preview changes](https://stackoverflow.com/questions/3636914/how-can-i-see-what-i-am-about-to-push-with-git), gives all the information about how to preview changes from your machine. There's also another option to preview using online environment. This [link](https://dillinger.io/) takes you to the online environment.
 
  NOTE: In case you have come up with the wrong edit and if you'd like to revert it back to the previous version of the file follow this        [link](https://githowto.com/undoing_local_changes). This is applicable only before committing the change.
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2491

### Description
In step 6, at Preview Changes Locally, at sentence "how to preview change" which is embedded an URL. However, when I click on that and open this URL. The new page opened is a Q&A page and I can not find any information relating "how to preview changes". I am not sure the URL is correct or not. However, if it is correct, I think you should give more explanation because I totally can not understand how these information is relating to each other.

"How to preview change" in Step 6
![1](https://user-images.githubusercontent.com/49819696/60387934-f725ae80-9a6f-11e9-8433-6e82528edb82.png)

Then, the new page after clicking: 
![2](https://user-images.githubusercontent.com/49819696/60387938-16244080-9a70-11e9-9ff4-66cd96535b9b.png)

### Proposed solution
If the URL is incorrect, modify to correct URL
If the URL is correct, need more detail explanation about that

### Raw.Githack preview link
https://raw.githack.com/275vytran/275vytran.github.io/275vytran/#!./pages/vi/vi-github-issues.md
<!-- raw.githack link to page(s) changed -->
