### PR TITLE
The GitHub help link has died (Fixes #2494)

### DIFF
--- a/pages/vi/vi-faq.md
+++ b/pages/vi/vi-faq.md
@@ -1,4 +1,4 @@
-# FAQ
+﻿# FAQ
 
 ## General Internship Questions
 
@@ -225,7 +225,7 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 
 * General
     - [GitHub and Markdown Short Tutorials](https://guides.github.com/)
-    - [GitHub Help](https://help.github.com/categories/search/)
+    - [GitHub Help](https://help.github.com/en/categories/github-pages-basics)
     - [Git Cheat Sheet (PDF)](https://education.github.com/git-cheat-sheet-education.pdf)
 
 * First Steps


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2494

### Description
In FAQ page, at Helpful Links, the Github Help link died.
![sddsd](https://user-images.githubusercontent.com/49819696/60394045-9c2d9f00-9ae3-11e9-8a4d-56203b68dbd3.png)

When clicking on Github Help:
![dsads](https://user-images.githubusercontent.com/49819696/60394055-cbdca700-9ae3-11e9-95fc-ccc26bb71f13.png)

Solution: I already change to the new working link.

### Raw.Githack preview link
https://raw.githack.com/275vytran/275vytran.github.io/branch4/#!pages/vi/vi-faq.md
<!-- raw.githack link to page(s) changed -->
