### PR TITLE
Remove duplicate Markdown resource (fixes #2539)

### DIFF
--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -24,8 +24,6 @@ A Markdown cheat sheet that might help you create your own Markdown page later:
 
 [GitHub – Mastering Markdown](https://guides.github.com/features/mastering-markdown/) - The official GitHub Guide for Markdown syntax.
 
-[Markdown Tutorial](https://tylingsoft.github.io/tutorial.md/#whats-markdown) - An interactive tutorial to learn Markdown.
-
 [Markdown cheat sheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) - A bigger Markdown cheat sheets with examples
 
 [Markdown Tutorial](https://tylingsoft.github.io/tutorial.md/#whats-markdown) - An interactive tutorial to learn Markdown.


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2539 

### Description
This pull request removes the "Markdown Tutorial - An interactive tutorial to learn Markdown" on the 2nd line of the Markdown resource list, which locates after the two screenshots for Markdown syntax on [Github and Markdown page](http://open-learning-exchange.github.io/#!./pages/vi/vi-github-and-markdown.md). 

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
https://raw.githack.com/SiqiuMa/SiqiuMa.github.io/siqiu-issue-branch1/#!pages/vi/vi-github-and-markdown.md

### Checklist
- [x] Check for issue number in pull request title
- [x] Are there any unneeded files in the pull request?
- [x] Did they make a branch for their patch?
- [x] Does the pull request actually fix the issue?
- [x] Check the pull request on raw.githack, does it display without any errors?
- [x] Is there any merge conflicts?
- [x] Make sure that people use their GitHub accounts when making commits through git