### PR TITLE
Add notes to First Steps and Github Issues Pages to Clarify it is OK to Move On (fixes #2554)

### DIFF
--- a/pages/vi/vi-first-steps.md
+++ b/pages/vi/vi-first-steps.md
@@ -75,12 +75,14 @@ Follow the directions at [Git Repositories](vi-github-and-repositories.md) to ke
 
 Follow the tutorial under the [GitHub Issues tab](vi-github-issues.md) to create at least one issue. Post a link in [Gitter](https://gitter.im/open-learning-exchange/chat) whenever you create an issue or when you comment on someone else's issue. You are encouraged to post as many issues as you can for improving the page as well as for personal practice. No issue is too big or too small to be filed and it is OK if you are not sure how to fix it yourself. If you know how to solve an issue, be sure to provide a detailed account of your research and show how to fix it. It is ok to file an issue about minor typos and very small changes, but do not make this the case for all of the issues that you file. You can also work on issues that you didn't create.
 
-Make sure you have created at least one issue, resolved it, commented on an issue you didn't create and have a pull request with the fix merged before proceeding to the next step.
+Make sure you have created at least one issue, resolved it, commented on an issue you didn't create and have a pull request with the fix merged. You may continue making Issues, Pull requests and Comments, or move on to the next step, while you are waiting for your pull request to be merged. The approval process for your Step 6 fix may take time, but it is OK to continue working.
 
 - Once you complete Step 6 you will have:
    * 2 pull requests made (one at step 3 and one at step 6)
    * 1 comment added (on an issue you didn't create)
    * 1 issue created
+
+Please note that creating and working on Issues are not exactly bound by the "Step" you are in. Feel free to move on to other steps, and make more Issues and Pull Requests while you wait on OLE approval for your merge(s). 
 
 ## Step 7 - Nation Planet
 

--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -132,6 +132,8 @@ Additionally, creating a checklist will help others understand what you have don
 
 Some of these items are of course optional, but try to include as much useful information for others as possible in your checklists because nobody really wants to work on something that has already been completed by someone else.
 
+NOTE: While you are waiting on two OLE team members to approve your Pull Requests, it is OK to keep creating more Issues and Pull Requests in the meantime. They will all count towards your final Issue/PR total, and PR approval can take time, so do not let a lengthy approval/fix process keep you from moving on in your "First Steps".
+
 ## Delete the Branch
 
 *  **Wait for the pull request merge!**


### PR DESCRIPTION


<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2554 

### Description
I have added notes to both the "Github Issues" pages and "First Steps" pages(in the Step 6 Section) to make it clearer that Aspiring VI's can continue working on Issues and Pull requests while waiting on approval for another one. This lets them know that they can continue making progress and move on to the next step if their Pull Request has not yet been merged. Removed the words that said you must have your Step 6 PR merged **before** moving on. See #2554 for more discussion on this issue.

Anything else I can add to improve these changes, please allow me to know.

Checklist

[x] Check for issue number in pull request title
[x] Are there any unneeded files in the pull request?
[x] Did they make a branch for their patch?
[x] Does the pull request actually fix the issue?
[x] Check the pull request on raw.githack, does it display without any errors?
[x] Is there any merge conflicts?
[x] Make sure that people use their GitHub accounts when making commits through git


### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->

https://raw.githack.com/johnmdrake1/johnmdrake1.github.io/issues-and-pr-clarification-johnmdrake1/#!pages/vi/vi-first-steps.md

https://raw.githack.com/johnmdrake1/johnmdrake1.github.io/issues-and-pr-clarification-johnmdrake1/#!pages/vi/vi-github-issues.md

