### PR TITLE
Add git cheat sheet link vi-github-and-markdown.md (Fixes #2599)

### DIFF
--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -24,6 +24,8 @@ A Markdown cheat sheet that might help you create your own Markdown page later:
 
 [GitHub – Mastering Markdown](https://guides.github.com/features/mastering-markdown/) - The official GitHub Guide for Markdown syntax.
 
+[Git Cheat Sheet](https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf) - A resource for commonly used git commands.
+
 [Markdown cheat sheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) - A bigger Markdown cheat sheets with examples
 
 [Markdown Tutorial](https://tylingsoft.github.io/tutorial.md/#whats-markdown) - An interactive tutorial to learn Markdown.


### PR DESCRIPTION
Fixes #2599 

### Description
Added the cheat sheet provided by Github for commonly
used commands in git. This should help direct new interns
to an easily accessible reference for the proper syntax when
using git commands.

### Raw.Githack preview link
https://raw.githack.com/bradlet/bradlet.github.io/githubSheet/#!pages/vi/vi-github-and-markdown.md
