### PR TITLE
Added option 1 and option 2 label in courses page (Fixed #2606)

### DIFF
--- a/pages/manual/planet/course.md
+++ b/pages/manual/planet/course.md
@@ -16,11 +16,11 @@ Topics:
 ## Getting to the Courses Page
 There are two ways to get to the Courses page:
 
-1. From the Navigation Bar, click on the "Courses" Tab at the top.
+1.[Option 1] From the Navigation Bar, click on the "Courses" Tab at the top.
 
 ![Getting to courses with Navigation Bar](images/get-courses-navbar.png)
 
-2. From the dashboard tile, click on the "myCourses" tile right on the front page.
+2.[Option 2] From the dashboard tile, click on the "myCourses" tile right on the front page.
 
 ![Getting to courses with dashboard](images/get-courses-tile.png)
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2606 

### Description
My first pull request for this issue was a disaster because there were a few changes make along with this issue so I make a new PR.

I added Option 1 and Option 2 label when it giving out 2 ways to get to the courses page. Let me know, if they are some issue with this PR, I'll try to fix it again. Thank


Note: I'm not sure if you guys noticed that in some pages, it seem like numbers are duplicated. for example, when there is a steps, it will listed #1. Exampel1   #1.Example2 but when I check the code it listed  #1.Example1 #2.Example2. I'm not sure why it doesn't display just like the code. This is the reason why I created this issue,so the change that I made might not be necessary in the future.

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
 
https://raw.githack.com/aasenomad/aasenomad-ole.github.io/optionbranch/#!./pages/manual/planet/./course.md
