### PR TITLE
Added the Exams title on manaual page (fixed #2623)

### DIFF
--- a/pages/manual/planet/overview.md
+++ b/pages/manual/planet/overview.md
@@ -70,6 +70,8 @@ The Courses page is where you can create and join a variety of different courses
 ## Teams
 Here you will be able to create teams to communicate with them, offer courses, and organize members. Click [here](teams.md) to learn more about Teams
 
+## Exams
+
 ## Surveys
 
 ## Meetups


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2623 

### Description

I added the Exams title on the manual page. Now, you will see Exams title right above Surveys title without descriptions.


### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->

https://raw.githack.com/aasenomad/aasenomad-ole.github.io/addexams/#!pages/manual/planet/overview.md
