### PR TITLE
Fixed the redundancy on "git repositories" page (fixes #2706)

### DIFF
--- a/pages/vi/vi-github-and-repositories.md
+++ b/pages/vi/vi-github-and-repositories.md
@@ -2,9 +2,9 @@
 
 ## Objectives
 
-* Understanding Git repositories and levels
-* Learning how to use Git from the command line
-* Configuring and syncing your repository
+- Understanding Git repositories and levels
+- Learning how to use Git from the command line
+- Configuring and syncing your repository
 
 ## Introduction
 
@@ -18,23 +18,21 @@ As previously mentioned, you fork a repository to work on your own GitHub accoun
 
 This is just a summary of the steps that you will need to perform. Please, keep on reading for a detailed explanation of each step.
 
+- [Clone Your GitHub Repository username.github.io](#Clone_Your_GitHub_Repository_username.github.io)
+- [Clone with HTTPS or Clone with SSH?](#Clone_with_HTTPS_or_Clone_with_SSH?)
+- [Explanation About Repositories and Syncing Process](#Explanation_About_Repositories_and_Syncing_Process)
+- [Configure a Remote Repository for Your Fork](#Configure_a_Remote_Repository_for_Your_Fork)
+- [Sync Your Fork](#Sync_Your_Fork)
 
-
-* [Clone Your GitHub Repository username.github.io](#Clone_Your_GitHub_Repository_username.github.io)
-* [Clone with HTTPS or Clone with SSH?](#Clone_with_HTTPS_or_Clone_with_SSH?)
-* [Explanation About Repositories and Syncing Process](#Explanation_About_Repositories_and_Syncing_Process)
-* [Configure a Remote Repository for Your Fork](#Configure_a_Remote_Repository_for_Your_Fork)
-* [Sync Your Fork](#Sync_Your_Fork)
-
-**NOTE**: You will see some common names used in git (*which you can change*), such as `master: the name of the main branch`, `upstream: the location where you forked the repository from`, and `origin: the location you cloned repository from`. Both `upstream and origin` are considered **remote**. Keep in mind also, a repository may contain many branches.
+**NOTE**: You will see some common names used in git (_which you can change_), such as `master: the name of the main branch`, `upstream: the location where you forked the repository from`, and `origin: the location you cloned repository from`. Both `upstream and origin` are considered **remote**. Keep in mind also, a repository may contain many branches.
 
 ### Clone Your GitHub Repository username.github.io
 
-Now, we will be using GitHub repositories on a command line, which means that there is a separate step to get your GitHub repository on your OS. To be clear, you will be using both the command line and the GitHub user interface, meaning that you need to constantly be checking to make sure that your version is not behind to avoid merge conflicts. Therefore, open a command line and open your username.github.io repository on the  GitHub user interface. You then need to copy the link provided in the repository (see the picture below).
+Now, we will be using GitHub repositories on a command line, which means that there is a separate step to get your GitHub repository on your OS. To be clear, you will be using both the command line and the GitHub user interface, meaning that you need to constantly be checking to make sure that your version is not behind to avoid merge conflicts. Therefore, open a command line and open your username.github.io repository on the GitHub user interface. You then need to copy the link provided in the repository (see the picture below).
 
 ![GitHub Clone URL](images/vi-github-clone-url.png)
 
-Then, turn to your command prompt and type your repository URL in the form of `git clone https://github.com/EmilyLarkin/EmilyLarkin.github.io.git` into the command line. Be sure to use the correct URL to clone your repository (you will obviously type your own username).  If you  `cd  ` into your `username.github.io` you can see different files which you will be working on during your internship.
+Then, turn to your command prompt and type your repository URL in the form of `git clone https://github.com/EmilyLarkin/EmilyLarkin.github.io.git` into the command line. Be sure to use the correct URL to clone your repository (you will obviously type your own username). If you `cd` into your `username.github.io` you can see different files which you will be working on during your internship.
 
 ### Clone with HTTPS or Clone with SSH?
 
@@ -48,7 +46,7 @@ The previous step created a clone of your repository on your OS.
 
 Now, there are three different Github repository levels: [open-learning-exchange.github.io](https://github.com/open-learning-exchange/open-learning-exchange.github.io), your username.github.io on GitHub, and your username.github.io on your OS. These three levels need to be constantly synced and up to date with one another as we will all be contributing to the upstream repository (open-learning-exchange.github.io). It's important to try and keep these separate and avoid mixing changes between them, as you will be unable to fork and git push/pull if they are very different versions.
 
-As you create a fork from the original repository and then clone your forked repository onto your OS, you will need to frequently update the fork so that your fork and clone are not behind. Further, you need to sync your repository on your OS and on GitHub (username.github.io) with the upstream repository (open-learning-exchange.github.io). There are various ways to do this, as explained below.
+As you create a fork from the original repository and then clone your forked repository onto your OS, you will need to frequently update the fork so that your fork and clone are not behind. Further, you need to sync your repository on your OS and GitHub (username.github.io) with the upstream repository (open-learning-exchange.github.io). There are various ways to do this, as explained below.
 
 First, the [GitHub help section](https://help.github.com/en) and the [Git website](https://git-scm.com) are incredibly helpful in answering your basic questions. For example, [this link](https://help.github.com/articles/syncing-a-fork/) explains how to sync a fork with the correct upstream repo, because as you renamed your repository, it does not automatically assume that open-learning-exchange.github.io is the source. Instead, it assumes that username.github.io is the master which fails to allow a proper syncing process. Therefore, when you do `git diff` and `git status`, it only looks at your username.github.io. Thus, following the steps below, you will need to use `git fetch upstream`, `git checkout master`, and `git merge upstream/master` to correctly sync to open-learning-exchange.github.io (see the diagram below).
 
@@ -61,6 +59,7 @@ To be able to fetch updates from the upstream repository, you need to first conf
 1. Open your command prompt/terminal and find the correct directory, `cd username.github.io.`
 
 2. List the current configured remote repository for your fork with `git remote -v`. This is what it should look like:
+
 ```
 $ git remote -v
 origin  https://github.com/username/username.github.io.git (fetch)
@@ -68,11 +67,13 @@ origin  https://github.com/username/username.github.io.git (push)
 ```
 
 3. Specify a new remote upstream repository that will be synced with the fork by using `git remote add upstream <repository>`. Our remote upstream repository will be https://github.com/open-learning-exchange/open-learning-exchange.github.io.git. Do not forget the `.git` at the end.
+
 ```
 $ git remote add upstream https://github.com/open-learning-exchange/open-learning-exchange.github.io.git
 ```
 
 4. Verify if upstream is configured correctly with `git remote -v`.
+
 ```
 $ git remote -v
 origin  https://github.com/username/username.github.io.git (fetch)
@@ -96,6 +97,7 @@ EmilyLarkin.github.io $ git checkout master
 Already on 'master'
 Your branch is up-to-date with 'origin/master'.
 ```
+
 **NOTE**: If there are any errors after `git fetch upstream`, please check for typos from previous step. If so, use `git remote rm upstream` and add the repo in upstream again
 
 Then, use `git merge upstream/master` to merge the open-learning-exchange upstream/master with your local repository. It should look something like this:
@@ -118,19 +120,22 @@ aborts the commit.
 ~
 ~
 ```
-it means that you are in the Vim text editor. Simply type ```:wq``` which stands for **w**rite and **q**uit. However, if you want to insert something you can type "i" and Vim goes into edit mode. To exit edit mode just hit "escape".
+
+it means that you are in the Vim text editor. Simply type `:wq` which stands for **w**rite and **q**uit. However, if you want to insert something you can type "i" and Vim goes into edit mode. To exit edit mode just hit "escape".
 
 Now, your repository has been synced to the upstream/master. However, a discrepancy may still exist between your local (and now your origin/master) versus your username.github.io on GitHub. You will now use `git diff` and `git status` to check how your local repository compares to your username.github.io repository. Depending on whether you have more or less commits than your username.github.io, you will either use `git pull` to receive any changes or `git push` to push updates to your repository. Most likely, as you just synced with the master, you will use `git push` to push updates to your username.github.io repo.
-``` bash
+
+```bash
 $ git push origin master
 ```
+
 If you have uncommitted changes (from mixing interface and terminal use of GitHub repositories), then these commands will be aborted until you fix the discrepancy.
 
 Remember, you should repeatedly use the commands `git diff` and `git status` to respectively see the difference between your username.github.io and your local repository and then see the status of your repository and the changes you have made. Once again, you need to sync your repository with the correct master first, otherwise you will not see the correct `git diff` and `git status`. `git diff` and `git status` only look between your local and username.github.io repos, not your upstream repo.
 
 Below is an example of **git diff** command showing difference in the file of local and remote repository.
 
-``` bash
+```bash
 $ git diff
 diff --git a/<file name>.md b/<file name>.md
 index bf400c0..fc7380b 100644
@@ -139,6 +144,7 @@ index bf400c0..fc7380b 100644
 @@ -1,5 +1 @@
  What is this?
 ```
+
 **What does `diff --git a/<file name>.md b/<file name>.md` mean?**
 
 **Answer:** Our diff compares two items with each other: item A and item B. In most cases, A and B will be the same file, but in different versions. To make clear what is actually compared, a diff output always starts by declaring which files are represented by "A" and "B".
@@ -154,11 +160,13 @@ This process needs to be repeated whenever you begin to work, to make sure that 
 Generally, follow these commands in your command line, but refer back above if there are any errors or further questions about why you are writing any of the following commands
 
 #### Clone your GitHub repository username.github.io
+
 1. Open your command prompt/terminal and find the correct directory
 2. Copy the HTTPS or SSH link from your repository on the GitHub site
 3. On the command line, type `git clone *paste your HTTPS or SSH link here*`
 
 #### Understand that there are three levels of a Github repository:
+
 - the upstream ([open-learning-exchange.github.io](https://github.com/open-learning-exchange/open-learning-exchange.github.io))
 - Your username.github.io on GitHub
 - Your username.github.io on your OS.
@@ -167,18 +175,21 @@ These need to be synced and checked constantly.
 The **upstream repository** is the one we are contributing to.
 
 #### Configure the upstream repository to your fork
+
 1. `cd username.github.io.`
 2. `git remote -v` see above to make sure you are pushing and fetching to your own repository on GitHub as the origin
 3. `git remote add upstream https://github.com/open-learning-exchange/open-learning-exchange.github.io.git`
 4. `git remote -v` origins should remain the same, but you should also be fetching and pushing to OLE as the upstream now
 
 #### Sync Your Fork
-1. `git fetch upstream` -  to fetch branches from the upstream repository ([more info](https://git-scm.com/docs/git-fetch))
+
+1. `git fetch upstream` - to fetch branches from the upstream repository ([more info](https://git-scm.com/docs/git-fetch))
 2. `git checkout master` - to checkout the `master` branch ([more info](https://git-scm.com/docs/git-checkout))
 3. `git show-branch` - to see branches and the changes made in them ([more info](https://git-scm.com/docs/git-show-branch))
 4. `git merge upstream/master` - You repository should now be synced to upstream/master ([more info](https://git-scm.com/docs/git-merge))
 
 #### Make sure your repository is up to date
+
 1. `git diff` - for comparing different versions of the same file ([more info](https://git-scm.com/docs/git-diff))
 2. `git status` - to view the changes made in the branch, whether the branch is up-to-date with master ([more info](https://git-scm.com/docs/git-status))
 3. `git pull` - to sync the local repository with the remote repository ([more info](https://git-scm.com/docs/git-pull))
@@ -187,6 +198,7 @@ The **upstream repository** is the one we are contributing to.
 **NOTE**: Developers should always sync their fork and make sure their repositories are up to date with GitHub every time they begin to work. This way we as a team can minimize data loss, and can save you some time.
 
 #### If you find yourself needing to rebase your forked repository, the following two links should help:
+
 - [Rebase](https://git-scm.com/docs/git-rebase)
 - [Branching Rebasing](https://git-scm.com/book/en/v2/Git-Branching-Rebasing)
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2706 

### Description
This update removes the redundant 'on' from the paragraph that is two paragraphs below "Explanation about Repositories and Syncing Process".


### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
(https://raw.githack.com/smitshrestha101/smitshrestha101.github.io/git-reposit-update/#!pages/vi/vi-github-and-repositories.md)
