### PR TITLE
fixed redundant text on translator/introduction page

### DIFF
--- a/pages/translators/la-introduction.md
+++ b/pages/translators/la-introduction.md
@@ -1,6 +1,6 @@
 # Translation Support	
 
-Welcome to the translation support section. We very much appreciate any and all translation support. Thank you for your interest in our software!
+Welcome to the translation support section. We appreciate any and all translation support. Thank you for your interest in our software!
 
 ## The Big Picture
 


### PR DESCRIPTION
<!-- issue number this pull request resolves -->
Fixes #2724 

### Description
removes redundant text on translator introduction pages

### Before
<img width="1417" alt="Screen Shot 2019-09-12 at 11 55 41 AM" src="https://user-images.githubusercontent.com/41179777/64813808-12746600-d557-11e9-89cb-b97b33b00004.png">

### After
<img width="1404" alt="Screen Shot 2019-09-12 at 11 53 25 AM" src="https://user-images.githubusercontent.com/41179777/64813818-17d1b080-d557-11e9-92aa-395c91ce6df7.png">


### Raw.Githack preview link
https://raw.githack.com/justin-singh125125/justin-singh125125.github.io/translate/introduction-text/#!pages/translators/la-introduction.md
