### PR TITLE
Updates to Q13 community address (fixes #2679)

### DIFF
--- a/pages/vi/vi-faq.md
+++ b/pages/vi/vi-faq.md
@@ -84,7 +84,7 @@
 
 #### Q13: Why does Firefox say “Unable to connect” when I try to load my Community?
 
-+ Because a Community is run locally on your machine, you need to `vagrant up` in the directory where the Vagrantfile is located. You can then see if your Community is running by going to `127.0.0.1:5985` in Firefox. Go to `127.0.0.1:5985/_utils` to see the CouchDB behind the Planet, and `127.0.0.1:5985/apps/_design/bell/MyApp/index.html` to navigate the actual Planet user interface.
++ Because a Community is run locally on your machine, you need to `vagrant up` in the directory where the Vagrantfile is located. You can then see if your Community is running by going to `http://localhost:3100/` in Firefox. Go to `127.0.0.1:5984/_utils` to see the CouchDB behind the Planet, and `127.0.0.1:5984/apps/_design/bell/MyApp/index.html` to navigate the actual Planet user interface.
 
 #### Q14: When I first run Planet with the "vagrant up" command, why does the download fail?
 


### PR DESCRIPTION
### Fixes #2679 

### Description
* corrected local host address to updated address planet tutorial
* updated from 127.0.0.1:5985 to 127.0.0.1:5984 due to couch docs

### Raw.Githack preview link
https://raw.githack.com/nvrqt03/nvrqt03.github.io/nvrqt03-update-2679/#!pages/vi/vi-faq.md 

[x] Check for issue number in pull request title
[x] Are there any unneeded files in the pull request?
[x] Did they make a branch for their patch?
[x] Does the pull request actually fix the issue?
[x] Check the pull request on raw.githack, does it display without any errors?
[x] Is there any merge conflicts?
[x] Make sure that people use their GitHub accounts when making commits through git