### PR TITLE
Added basic command line commands list in the FAQ/Helpful Links #2769

### DIFF
--- a/pages/vi/vi-faq.md
+++ b/pages/vi/vi-faq.md
@@ -220,6 +220,9 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 
 ## Helpful Links
 
+#### *Command line commands*
+- [List of command line commands](https://www.codecademy.com/articles/command-line-commands)
+
 #### *Docker*
 
 - [What is Docker?](https://www.docker.com/what-docker)
@@ -230,9 +233,6 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 - [Docker Installation](http://open-learning-exchange.github.io/#!./pages/vi/vi-docker-installation.md)
 
 #### *GitHub and Markdown*
-
-* Command line commands
-    - [List of command line commands](https://www.codecademy.com/articles/command-line-commands)
 
 * General
     - [GitHub and Markdown Short Tutorials](https://guides.github.com/)

--- a/pages/vi/vi-faq.md
+++ b/pages/vi/vi-faq.md
@@ -231,6 +231,8 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 
 #### *GitHub and Markdown*
 
+* Command line commands
+    - [List of command line commands](https://www.codecademy.com/articles/command-line-commands)
 
 * General
     - [GitHub and Markdown Short Tutorials](https://guides.github.com/)


### PR DESCRIPTION
### Fixes Issue 2769

### Description
I added a section named Command line commands at the beginning of the Helpful Links and attached following link: https://www.codecademy.com/articles/command-line-commands

### Raw.Githack preview link
https://raw.githack.com/anikx7/anikx7.github.io/Issue2769/#!./pages/vi/vi-faq.md

![2769](https://user-images.githubusercontent.com/26880012/66597539-cb34c180-eb64-11e9-8ae6-96c05eacf74c.JPG)

