### PR TITLE
adding the link to each step for issue 2747

### DIFF
--- a/pages/vi/vi-configurations-vagrant.md
+++ b/pages/vi/vi-configurations-vagrant.md
@@ -88,7 +88,7 @@ in your planet folder. This destroys and removes your community, pulls the lates
 
 5. When you are trying to access http://localhost:3100 the page may not load at all, even if your account was configured correctly and fully approved. A first step would be to run `vagrant halt prod`. Then, you should proceed to clear the cookies from your browser. This step will be different for each browser. Finally, you should run `vagrant up prod` to restart the VM before you reopen the browser to access the Planet again. **If this does not work, follow the previous steps above to rebuild your planet account.**
 
-## Next Section (Step 1.3) **→**
+## Next Section ([Step 1.3](https://open-learning-exchange.github.io/#!pages/vi/vi-vagrant.md)) **→**
 
 Now you have configured your community Planet, head over to [Vagrant Tutorial](vi-vagrant.md) to learn about how to interact with Vagrant through the command-line interface. You should be familiar with this since you will need to use it to control virtual machines during your internship.
 

--- a/pages/vi/vi-configurations-vagrant.md
+++ b/pages/vi/vi-configurations-vagrant.md
@@ -88,7 +88,7 @@ in your planet folder. This destroys and removes your community, pulls the lates
 
 5. When you are trying to access http://localhost:3100 the page may not load at all, even if your account was configured correctly and fully approved. A first step would be to run `vagrant halt prod`. Then, you should proceed to clear the cookies from your browser. This step will be different for each browser. Finally, you should run `vagrant up prod` to restart the VM before you reopen the browser to access the Planet again. **If this does not work, follow the previous steps above to rebuild your planet account.**
 
-## Next Section ([Step 1.3](https://open-learning-exchange.github.io/#!pages/vi/vi-vagrant.md)) **→**
+## Next Section ([Step 1.3](vi-vagrant.md)) **→**
 
 Now you have configured your community Planet, head over to [Vagrant Tutorial](vi-vagrant.md) to learn about how to interact with Vagrant through the command-line interface. You should be familiar with this since you will need to use it to control virtual machines during your internship.
 

--- a/pages/vi/vi-docker-tutorial.md
+++ b/pages/vi/vi-docker-tutorial.md
@@ -272,7 +272,7 @@ Commands:
 [Docker CLI Command](https://docs.docker.com/engine/reference/commandline/cli/)
 [Docker Installation](http://open-learning-exchange.github.io/#!./pages/vi/vi-docker-installation.md)
 
-## Next Section _(Step 3)_ **→**
+## Next Section _([Step 3](https://open-learning-exchange.github.io/#!pages/vi/vi-github-and-markdown.md))_ **→**
 
 Markdown is a lightweight markup language with plain text formatting syntax. In the next section, you will learn Markdown to create a profile page, and learn how to create a pull request.
 

--- a/pages/vi/vi-docker-tutorial.md
+++ b/pages/vi/vi-docker-tutorial.md
@@ -272,7 +272,7 @@ Commands:
 [Docker CLI Command](https://docs.docker.com/engine/reference/commandline/cli/)
 [Docker Installation](http://open-learning-exchange.github.io/#!./pages/vi/vi-docker-installation.md)
 
-## Next Section _([Step 3](https://open-learning-exchange.github.io/#!pages/vi/vi-github-and-markdown.md))_ **→**
+## Next Section _([Step 3](vi-github-and-markdown.md))_ **→**
 
 Markdown is a lightweight markup language with plain text formatting syntax. In the next section, you will learn Markdown to create a profile page, and learn how to create a pull request.
 

--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -179,7 +179,7 @@ After your pull request has been **approved** and **merged** by OLE staff, you m
 
 [Other helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _([Step 4](https://open-learning-exchange.github.io/#!pages/vi/vi-planetapps.md))_ **→**
+## Next Section _([Step 4](vi-planetapps.md))_ **→**
 
 In the next step, you will learn more about your community Planet, and the Planet interface.
 

--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -179,7 +179,7 @@ After your pull request has been **approved** and **merged** by OLE staff, you m
 
 [Other helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _(Step 4)_ **→**
+## Next Section _([Step 4](https://open-learning-exchange.github.io/#!pages/vi/vi-planetapps.md))_ **→**
 
 In the next step, you will learn more about your community Planet, and the Planet interface.
 

--- a/pages/vi/vi-github-and-repositories.md
+++ b/pages/vi/vi-github-and-repositories.md
@@ -206,7 +206,7 @@ If you would like to understand how syncing with the fork works, here is a usefu
 [Git help](https://git-scm.com/) - An encyclopedia of useful git workflows and terminology explanations.
 [Other helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _([Step 6](https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-github-issues.md))_ **→**
+## Next Section _([Step 6](vi-github-issues.md))_ **→**
 
 In the next section, you will learn the process for creating and resolving issues with GitHub.
 

--- a/pages/vi/vi-github-and-repositories.md
+++ b/pages/vi/vi-github-and-repositories.md
@@ -206,7 +206,7 @@ If you would like to understand how syncing with the fork works, here is a usefu
 [Git help](https://git-scm.com/) - An encyclopedia of useful git workflows and terminology explanations.
 [Other helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _(Step 6)_ **→**
+## Next Section _([Step 6](https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-github-issues.md))_ **→**
 
 In the next section, you will learn the process for creating and resolving issues with GitHub.
 

--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -157,7 +157,7 @@ This is an exercise to help you familiarize with GitHub issues, committing, and 
 [Helpful links and videos](vi-faq.md#Helpful_Links)
 [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 
-## Next Section _([Step 7](https://open-learning-exchange.github.io/#!pages/vi/vi-github-and-repositories.md))_ **→**
+## Next Section _([Step 7](vi-github-and-repositories.md))_ **→**
 
 In the next step, you will learn how to sync your Community Planet with the Nation.
 

--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -157,7 +157,7 @@ This is an exercise to help you familiarize with GitHub issues, committing, and 
 [Helpful links and videos](vi-faq.md#Helpful_Links)
 [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 
-## Next Section _(Step 7)_ **→**
+## Next Section _([Step 7](https://open-learning-exchange.github.io/#!pages/vi/vi-github-and-repositories.md))_ **→**
 
 In the next step, you will learn how to sync your Community Planet with the Nation.
 

--- a/pages/vi/vi-github-issues.md
+++ b/pages/vi/vi-github-issues.md
@@ -157,7 +157,7 @@ This is an exercise to help you familiarize with GitHub issues, committing, and 
 [Helpful links and videos](vi-faq.md#Helpful_Links)
 [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 
-## Next Section _([Step 7](vi-github-and-repositories.md))_ **→**
+## Next Section _([Step 7](vi-nation.md))_ **→**
 
 In the next step, you will learn how to sync your Community Planet with the Nation.
 

--- a/pages/vi/vi-nation.md
+++ b/pages/vi/vi-nation.md
@@ -92,8 +92,6 @@ vagrant up prod
 
 [Helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _(Step 8)_ **→**
-
 In the next section, you will create and resolve more issues with GitHub.
 
 #### Return to [First Steps](vi-first-steps.md#Step_7_-_Nation_Planet)

--- a/pages/vi/vi-planet-installation-vagrant.md
+++ b/pages/vi/vi-planet-installation-vagrant.md
@@ -140,7 +140,7 @@ At this early stage, the simple solution would be using `vagrant destroy prod` t
 
 7. On Windows, if you are unable to run the PowerShell command at the beginning of Step 1 and get the error `powershell is not recognized as an internal or external command`. Try to add the following path variable to your system variables under Advanced Settings: `%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;`
 
-## Next Section ([Step 1.2](https://open-learning-exchange.github.io/#!pages/vi/vi-configurations-vagrant.md)) **→**
+## Next Section ([Step 1.2](vi-configurations-vagrant.md)) **→**
 
 Now  you have installed your community Planet, head over to [Planet Configurations](#!./pages/vi/vi-configurations-vagrant.md) to register your community with the nation.
 

--- a/pages/vi/vi-planet-installation-vagrant.md
+++ b/pages/vi/vi-planet-installation-vagrant.md
@@ -140,7 +140,7 @@ At this early stage, the simple solution would be using `vagrant destroy prod` t
 
 7. On Windows, if you are unable to run the PowerShell command at the beginning of Step 1 and get the error `powershell is not recognized as an internal or external command`. Try to add the following path variable to your system variables under Advanced Settings: `%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;`
 
-## Next Section (Step 1.2) **→**
+## Next Section ([Step 1.2](https://open-learning-exchange.github.io/#!pages/vi/vi-configurations-vagrant.md)) **→**
 
 Now  you have installed your community Planet, head over to [Planet Configurations](#!./pages/vi/vi-configurations-vagrant.md) to register your community with the nation.
 

--- a/pages/vi/vi-planetapps.md
+++ b/pages/vi/vi-planetapps.md
@@ -100,7 +100,7 @@ If the course "Virtual Interns" is not there, check `Manage Sync` of manager set
 
 [Helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _([Step 5](https://open-learning-exchange.github.io/#!pages/vi/vi-github-and-repositories.md))_ **→**
+## Next Section _([Step 5](vi-github-and-repositories.md))_ **→**
 
 In the next step, you will learn more about how our Git repositories work, and how to sync your own repository to keep up-to-date.
 

--- a/pages/vi/vi-planetapps.md
+++ b/pages/vi/vi-planetapps.md
@@ -100,7 +100,7 @@ If the course "Virtual Interns" is not there, check `Manage Sync` of manager set
 
 [Helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _(Step 5)_ **→**
+## Next Section _([Step 5](https://open-learning-exchange.github.io/#!pages/vi/vi-github-and-repositories.md))_ **→**
 
 In the next step, you will learn more about how our Git repositories work, and how to sync your own repository to keep up-to-date.
 

--- a/pages/vi/vi-vagrant.md
+++ b/pages/vi/vi-vagrant.md
@@ -122,7 +122,7 @@ or not commonly used. To see all subcommands, run the command
 [Wikipedia page on Vagrant](https://en.wikipedia.org/wiki/Vagrant_%28software%29)
 [Other helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _([Step 2](https://open-learning-exchange.github.io/#!pages/vi/vi-docker-tutorial.md))_ **→**
+## Next Section _([Step 2](vi-docker-tutorial.md))_ **→**
 
 Docker is a computer program that performs operating-system-level virtualization also known as containerization. In the next section, you will learn the basics of interacting with Docker and Docker Compose through the command-line interface and basic commands for maintaining your Planet installation.
 

--- a/pages/vi/vi-vagrant.md
+++ b/pages/vi/vi-vagrant.md
@@ -122,7 +122,7 @@ or not commonly used. To see all subcommands, run the command
 [Wikipedia page on Vagrant](https://en.wikipedia.org/wiki/Vagrant_%28software%29)
 [Other helpful links and videos](vi-faq.md#Helpful_Links)
 
-## Next Section _(Step 2)_ **→**
+## Next Section _([Step 2](https://open-learning-exchange.github.io/#!pages/vi/vi-docker-tutorial.md))_ **→**
 
 Docker is a computer program that performs operating-system-level virtualization also known as containerization. In the next section, you will learn the basics of interacting with Docker and Docker Compose through the command-line interface and basic commands for maintaining your Planet installation.
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2747 

### Description
I added the links to the next steps for virtual interns. I got rid of the link to step 8 because they just need to return to the first steps for step 8.

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-planet-installation-vagrant.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-configurations-vagrant.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-vagrant.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-docker-tutorial.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-github-and-markdown.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-planetapps.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-github-and-repositories.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-github-issues.md

https://raw.githack.com/garret123h/garret123h.github.io/link-to-steps/#!pages/vi/vi-nation.md


