### PR TITLE
Removing Links on Courses Page (fixes #2778)

### DIFF
--- a/pages/manual/planet/course.md
+++ b/pages/manual/planet/course.md
@@ -4,15 +4,6 @@
 [**Return Home**](./overview.md)
 
 
-Topics:
-1. [Getting to the Courses Page](#getting-to-the-courses-page)
-2. [List of Courses](#list-of-courses)
-3. [Actions on List Page](#actions-on-list-page)
-4. [Adding Course](#adding-course)
-5. [Course Collections](#course-collections)
-6. [Taking a Test](#taking-a-test)
-7. [Taking a Survey](#taking-a-survey)
-
 ## Getting to the Courses Page
 There are two ways to get to the Courses page:
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2778

### Description
Removes the links on Courses page of Planet User Manual.

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
https://raw.githack.com/sjkadali/sjkadali.github.io/remove-links-courses/#!pages/manual/planet/course.md

![Screenshot from 2019-10-14 11-44-14](https://user-images.githubusercontent.com/39105848/66764630-32f64f80-ee78-11e9-9acb-ac3582678d93.png)
