### PR TITLE
Removing Links on Meetups Page (fixes #2780)

### DIFF
--- a/pages/manual/planet/meetup.md
+++ b/pages/manual/planet/meetup.md
@@ -1,9 +1,4 @@
 # Meetups
-Topics:
-1. [Navigating To The Meetup Page](#navigating-to-the-meetup-page)
-2. [Available Actions On Meetup Page](#available-actions-on-meetup-page)
-3. [Adding Meetups](#adding-meetups)
-4. [Inviting Others](#inviting-others)
 
 ## Navigating To The Meetup Page
 As you can see below, once you are in your planet dashboard you can access the page using the **Dashboard Tile** (Red box) and the **Menu** (Blue box):


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2780

### Description
Removes the non-functional links on Meetups Page of Planet User Manual.

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
https://raw.githack.com/sjkadali/sjkadali.github.io/remove-links-meetups/#!pages/manual/planet/meetup.md

![Screenshot from 2019-10-14 12-30-38](https://user-images.githubusercontent.com/39105848/66767573-bdda4880-ee7e-11e9-9e46-338e79ae1611.png)
