### PR TITLE
Removing Links from Top of News Page (fixes #2867)

### DIFF
--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,4 +1,8 @@
 # News
+Topics:
+1. [Navigating To The News Page](News#Navigating_to_the_News_Page)
+2. [Adding A Story](News#Adding_a_Story)
+3. [Editing or Deleting Stories](News#Reply_Edit_and_Delete_Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -5,17 +5,17 @@ Topics:
 * [Adding a Story](#Adding-a-Story)
 * [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
-## Navigating to the News Page
+## <a id="Navigating-to-the-News-Page"></a>Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
 
 ![Access News](images/planet-news-dashboard.png)
 
-## Adding a Story
+## <a id="Adding-a-Story"></a>Adding a Story
 After navigating to the `News` Page, you will be able to browse previous stories and add one of your own as you can see below.
 
 ![Adding A Story](images/planet-news-post.png)
 
-## Reply, Edit and Delete Stories
+## <a id="Reply-Edit-and-Delete-Stories"></a>Reply, Edit and Delete Stories
 You can reply to a story by clicking on the reply icon on the post (Purple circle), edit a story by clicking the pencil icon (Red circle) and delete a story by clicking the garbage can icon (Blue circle)
 
 ![Reply, Edit and Delete Stories](images/planet-news-edit-delete.png)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -5,7 +5,7 @@ Topics:
 * [Adding a Story](#Adding-a-Story)
 * [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
-## Navigating to the News Page
+## <a id="Navigating-to-the-News-Page"></a>Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
 
 ![Access News](images/planet-news-dashboard.png)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,8 +1,8 @@
 # News
 Topics:
-1. [Navigating to the News Page](#Navigating-to-the-News-Page)
-2. [Adding a Story](#Adding-a-Story)
-3. [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
+* [Navigating to the News Page](#Navigating-to-the-News-Page)
+* [Adding a Story](#Adding-a-Story)
+* [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,9 +1,9 @@
 # News
 Topics:
 
-* [Navigating to the News Page](#wiki-Navigating-to-the-News-Page)
-* [Adding a Story](#wiki-Adding-a-Story)
-* [Editing or Deleting Stories](#wiki-Reply-Edit-and-Delete-Stories)
+* [Navigating to the News Page](news.md#Navigating-to-the-News-Page)
+* [Adding a Story](news.md#Adding-a-Story)
+* [Editing or Deleting Stories](news.md#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,9 +1,4 @@
 # News
-Topics:
-
-* [Navigating to the News Page](#Navigating-to-the-News-Page)
-* [Adding a Story](#Adding-a-Story)
-* [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,8 +1,4 @@
 # News
-Topics:
-1. [Navigating To The News Page](News#Navigating_to_the_News_Page)
-2. [Adding A Story](News#Adding_a_Story)
-3. [Editing or Deleting Stories](News#Reply_Edit_and_Delete_Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,15 +1,15 @@
 # News
 Topics:
-1. [Navigating To The News Page](#navigating-to-the-news-page)
-2. [Adding A Story](#adding-a-story)
-3. [Editing or Deleting Stories](#reply-edit-and-delete-stories)
+1. [Navigating To The News Page](#Navigating-to-the-News-Page)
+2. [Adding A Story](#Adding-a-Story)
+3. [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
-## Navigating To The News Page
+## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
 
 ![Access News](images/planet-news-dashboard.png)
 
-## Adding A Story
+## Adding a Story
 After navigating to the `News` Page, you will be able to browse previous stories and add one of your own as you can see below.
 
 ![Adding A Story](images/planet-news-post.png)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,8 +1,8 @@
 # News
 Topics:
-1. [Navigating to the News Page](news#Navigating-to-the-News-Page)
-2. [Adding a Story](news#Adding-a-Story)
-3. [Editing or Deleting Stories](news#Reply-Edit-and-Delete-Stories)
+1. [Navigating to the News Page](News#Navigating-to-the-News-Page)
+2. [Adding a Story](News#Adding-a-Story)
+3. [Editing or Deleting Stories](News#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -5,7 +5,7 @@ Topics:
 * [Adding a Story](#Adding-a-Story)
 * [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
-## <a id="Navigating-to-the-News-Page"></a>Navigating to the News Page
+## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
 
 ![Access News](images/planet-news-dashboard.png)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,8 +1,8 @@
 # News
 Topics:
-1. [Navigating to the News Page](News#Navigating-to-the-News-Page)
-2. [Adding a Story](News#Adding-a-Story)
-3. [Editing or Deleting Stories](News#Reply-Edit-and-Delete-Stories)
+1. [Navigating to the News Page](#Navigating-to-the-News-Page)
+2. [Adding a Story](#Adding-a-Story)
+3. [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,8 +1,8 @@
 # News
 Topics:
-1. [Navigating To The News Page](#Navigating-to-the-News-Page)
-2. [Adding A Story](#Adding-a-Story)
-3. [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
+1. [Navigating To The News Page](News#Navigating-to-the-News-Page)
+2. [Adding A Story](News#Adding-a-Story)
+3. [Editing or Deleting Stories](News#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,9 +1,9 @@
 # News
 Topics:
 
-* [Navigating to the News Page](#Navigating-to-the-News-Page)
-* [Adding a Story](#Adding-a-Story)
-* [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
+* [Navigating to the News Page](#wiki-Navigating-to-the-News-Page)
+* [Adding a Story](#wiki-Adding-a-Story)
+* [Editing or Deleting Stories](#wiki-Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -2,7 +2,7 @@
 Topics:
 1. [Navigating To The News Page](#navigating-to-the-news-page)
 2. [Adding A Story](#adding-a-story)
-3. [Editing or Deleting Stories](#editing-or-deleting-stories)
+3. [Editing or Deleting Stories](#reply-edit-and-delete-stories)
 
 ## Navigating To The News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
@@ -15,6 +15,6 @@ After navigating to the `News` Page, you will be able to browse previous stories
 ![Adding A Story](images/planet-news-post.png)
 
 ## Reply, Edit and Delete Stories
-You can reply a story by clicking reply icon on the post (Purple circle), edit a story by clicking the pencil icon (Red circle) and delete a story by clicking the garbage can icon (Blue circle)
+You can reply to a story by clicking on the reply icon on the post (Purple circle), edit a story by clicking the pencil icon (Red circle) and delete a story by clicking the garbage can icon (Blue circle)
 
 ![Reply, Edit and Delete Stories](images/planet-news-edit-delete.png)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,9 +1,9 @@
 # News
 Topics:
 
-* [Navigating to the News Page](news.md#Navigating-to-the-News-Page)
-* [Adding a Story](news.md#Adding-a-Story)
-* [Editing or Deleting Stories](news.md#Reply-Edit-and-Delete-Stories)
+* [Navigating to the News Page](#Navigating-to-the-News-Page)
+* [Adding a Story](#Adding-a-Story)
+* [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,5 +1,6 @@
 # News
 Topics:
+
 * [Navigating to the News Page](#Navigating-to-the-News-Page)
 * [Adding a Story](#Adding-a-Story)
 * [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -5,17 +5,17 @@ Topics:
 * [Adding a Story](#Adding-a-Story)
 * [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
-## <a id="Navigating-to-the-News-Page"></a>Navigating to the News Page
+## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
 
 ![Access News](images/planet-news-dashboard.png)
 
-## <a id="Adding-a-Story"></a>Adding a Story
+## Adding a Story
 After navigating to the `News` Page, you will be able to browse previous stories and add one of your own as you can see below.
 
 ![Adding A Story](images/planet-news-post.png)
 
-## <a id="Reply-Edit-and-Delete-Stories"></a>Reply, Edit and Delete Stories
+## Reply, Edit and Delete Stories
 You can reply to a story by clicking on the reply icon on the post (Purple circle), edit a story by clicking the pencil icon (Red circle) and delete a story by clicking the garbage can icon (Blue circle)
 
 ![Reply, Edit and Delete Stories](images/planet-news-edit-delete.png)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -1,8 +1,8 @@
 # News
 Topics:
-1. [Navigating To The News Page](News#Navigating-to-the-News-Page)
-2. [Adding A Story](News#Adding-a-Story)
-3. [Editing or Deleting Stories](News#Reply-Edit-and-Delete-Stories)
+1. [Navigating to the News Page](news#Navigating-to-the-News-Page)
+2. [Adding a Story](news#Adding-a-Story)
+3. [Editing or Deleting Stories](news#Reply-Edit-and-Delete-Stories)
 
 ## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -5,17 +5,17 @@ Topics:
 * [Adding a Story](#Adding-a-Story)
 * [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
-## Navigating to the News Page
+### Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
 
 ![Access News](images/planet-news-dashboard.png)
 
-## Adding a Story
+### Adding a Story
 After navigating to the `News` Page, you will be able to browse previous stories and add one of your own as you can see below.
 
 ![Adding A Story](images/planet-news-post.png)
 
-## Reply, Edit and Delete Stories
+### Reply, Edit and Delete Stories
 You can reply to a story by clicking on the reply icon on the post (Purple circle), edit a story by clicking the pencil icon (Red circle) and delete a story by clicking the garbage can icon (Blue circle)
 
 ![Reply, Edit and Delete Stories](images/planet-news-edit-delete.png)

--- a/pages/manual/planet/news.md
+++ b/pages/manual/planet/news.md
@@ -5,17 +5,17 @@ Topics:
 * [Adding a Story](#Adding-a-Story)
 * [Editing or Deleting Stories](#Reply-Edit-and-Delete-Stories)
 
-### Navigating to the News Page
+## Navigating to the News Page
 As you can see below, once you are in your planet dashboard you can access the page using `ourNews` (Red Box)
 
 ![Access News](images/planet-news-dashboard.png)
 
-### Adding a Story
+## Adding a Story
 After navigating to the `News` Page, you will be able to browse previous stories and add one of your own as you can see below.
 
 ![Adding A Story](images/planet-news-post.png)
 
-### Reply, Edit and Delete Stories
+## Reply, Edit and Delete Stories
 You can reply to a story by clicking on the reply icon on the post (Purple circle), edit a story by clicking the pencil icon (Red circle) and delete a story by clicking the garbage can icon (Blue circle)
 
 ![Reply, Edit and Delete Stories](images/planet-news-edit-delete.png)


### PR DESCRIPTION
Fixes #2867 

### Description
Removes the redundant links from the top of the page and maintains consistency throughout the manual.

### Raw.Githack preview link
https://raw.githack.com/mattscodeans/mattscodeans.github.io/fixing_news_links/#!./pages/manual/planet/news.md
