### PR TITLE
Fix typo in vi-configurations-vagrant (fixes #2921)

### DIFF
--- a/pages/vi/vi-configurations-vagrant.md
+++ b/pages/vi/vi-configurations-vagrant.md
@@ -28,7 +28,7 @@ Please go to [http://localhost:3100](http://localhost:3100) or run `vagrant glob
 
 ## Windows
 
-Open browser and browse [http://localhost:3100](http://localhost:3100). You should see the user interface of application (see below).  If you get an `Unable to connect` page, check out Q13 at [FAQ](vi-faq.md#Technical_Questions).
+Open browser and browse [http://localhost:3100](http://localhost:3100). You should see the user interface of application (see below).  If you get an `Unable to connect` page, check out Q14 at [FAQ](vi-faq.md#Technical_Questions).
 
 ## Database
 [CouchDB](https://en.wikipedia.org/wiki/CouchDB) (also known as Apache CouchDB) is a database software that we use for the Planet. You can see the backend interface of our CouchDB at http://localhost:2300/_utils. In _utils, you have the opportunity to see all data of your Planet application.

--- a/pages/vi/vi-faq.md
+++ b/pages/vi/vi-faq.md
@@ -88,7 +88,7 @@
 
 #### Q14: Why does Firefox say “Unable to connect” when I try to load my Community?
 
-+ Because a Community is run locally on your machine, you need to `vagrant up` in the directory where the Vagrantfile is located. You can then see if your Community is running by going to `http://localhost:3100/` in Firefox. Go to `127.0.0.1:5984/_utils` to see the CouchDB behind the Planet, and `127.0.0.1:5984/apps/_design/bell/MyApp/index.html` to navigate the actual Planet user interface.
++ Because a Community is run locally on your machine, you need to `vagrant up` in the directory where the Vagrantfile is located. You can then see if your Community is running by going to `http://localhost:3100/` in Firefox. Go to `127.0.0.1:2200/_utils` to see the CouchDB behind the Planet, and `127.0.0.1:3100` to navigate the actual Planet user interface.
 
 #### Q15: When I first run Planet with the "vagrant up" command, why does the download fail?
 


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2921 

### Description
In the "Windows" section of [Planet Configurations](https://open-learning-exchange.github.io/#!./pages/vi/vi-configurations-vagrant.md), changed "check out Q13" to "check out Q14". This is to fix a discrepancy where Q13 doesn't reference the unable to connect error, but Q14 does. 

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
[Raw Githack](https://raw.githack.com/jsschf/jsschf.github.io/update-vi-config-vagrant/#!pages/vi/vi-configurations-vagrant.md)