### PR TITLE
Typo quick start manual

### DIFF
--- a/pages/techgenius/tg-hardware-setup.md
+++ b/pages/techgenius/tg-hardware-setup.md
@@ -1,6 +1,6 @@
 # Planet Quick Start Manual
 
-This manual is designed to provide basic, step-by-step instructions for setting up the hardware for a Planet system based around a Rasperry Pi server. This manual also assumes the reader possesses some basic background on the Planet and its functionality; however, it does not assume the reader has a technical or software background.
+This manual is designed to provide basic, step-by-step instructions for setting up the hardware for a Planet system based around a Raspberry Pi server. This manual also assumes the reader possesses some basic background on the Planet and its functionality; however, it does not assume the reader has a technical or software background.
 
 ## How do I Connect the Planet Hardware?
 

--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -137,7 +137,7 @@ Now, check what this looks like on your own page `https://raw.githack.com/YourUs
 
 ### Open a pull request
 
-Once you have your profile ready, it's time to create a pull request. Click on one of the "Pull request" button as highlighted in the screenshot below.
+Once you have your profile ready, it's time to create a pull request. Click on one of the "Pull request" buttons as highlighted in the screenshot below.
 
 ![Initiate Pull Request](images/vi-initiate-pull-request.png)
 


### PR DESCRIPTION
Fixes # 2967

### Description
Changed the word Rasperry to Raspberry to correct typo.

### Raw.Githack preview link
https://raw.githack.com/chtelmko/chtelmko.github.io/TypoQuickStartManual/#!pages/techgenius/tg-hardware-setup.md
