### PR TITLE
Update links to redirect to secure/nondeprecated websites (fixes #2985)

### DIFF
--- a/pages/vi/vi-faq.md
+++ b/pages/vi/vi-faq.md
@@ -246,11 +246,11 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 
 * First Steps
     - [GitHub's Git Tutorial](https://try.github.io/)
-    - [Git-it Workshop](http://jlord.us/git-it/)
+    - [Git-it Workshop](https://jlord.us/git-it/)
     - [Codecademy's Learn Git Course](https://www.codecademy.com/learn/learn-git)
 
 * Intermediate
-    - [Git Immersion](http://gitimmersion.com/)
+    - [Git Immersion](https://git-immersion.github.io/gitimmersion/)
 
 * Reference/Advanced
     - [Git Pro (Book)](https://git-scm.com/book/en/v2)
@@ -288,7 +288,7 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 - [Vagrant Tutorial](https://scotch.io/tutorials/get-vagrant-up-and-running-in-no-time)
 
 #### *HTML*
-- [HTML5 Tutorial](https://www.w3schools.com/html/html5_intro.asp)
+- [HTML5 Tutorial](https://www.w3schools.com/html/html_intro.asp)
 
 #### *CSS*
 - [CSS Tutorial](https://www.w3schools.com/css/)


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #2985 

### Description
In the [FAQ](https://open-learning-exchange.github.io/#!pages/vi/vi-faq.md) under "Helpful Links" there were two URLs that pointed to unsecure websites and one URL that pointed to a deprecated website. 

Unsecure links:
+ [Git-it Workshop](http://jlord.us/git-it/) under "GitHub and Markdown - First Steps"
+ [Git Immersion](http://gitimmersion.com/) under "GitHub and Markdown - Intermediate"

Deprecated link:
+ [HTML5 Tutorial](https://www.w3schools.com/html/html5_intro.asp) under "HTML"

I updated the URLs in the links to point to their secure/nondeprecated versions.

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
https://raw.githack.com/jsschf/jsschf.github.io/fix-issue-2985/#!pages/vi/vi-faq.md