### PR TITLE
Add Mac Keys Reload Tip (Fixes #3073)

### DIFF
--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -131,7 +131,7 @@ If you need to edit your file again, click the pencil icon to edit (as shown bel
 Now, check what this looks like on your own page `https://raw.githack.com/YourUserName/YourUserName.github.io/YourBranchName/#!pages/vi/profiles/YourUserName.md`. The raw.githack link allows reviewers to preview your changes. Please double check that everything looks good and is working as you hoped before moving on to next section.
 
 **NOTE**:
-• If you don't see any changes in your page after editing your file then you need to clear your browser's cache or open your page in your browser's **"incognito"** or **"privacy"** mode. You can also press Ctrl+Shift+R or Ctrl+F5 (on Mac Cmd+Shift+R) to reload the page with cache cleared.
+• If you don't see any changes in your page after editing your file then you need to clear your browser's cache or open your page in your browser's **"incognito"** or **"privacy"** mode. You can also press Ctrl+Shift+R or Ctrl+F5 (on **Mac**: Cmd+Shift+R) to reload the page with cache cleared.
 • As MDwiki site is what we use for "production," please **always check** if everything renders as you expected using raw.githack link. There are [different flavors of Markdown](https://github.com/commonmark/CommonMark/wiki/Markdown-Flavors). Use GitHub's preview tab for reference only.
 
 

--- a/pages/vi/vi-github-and-markdown.md
+++ b/pages/vi/vi-github-and-markdown.md
@@ -131,7 +131,7 @@ If you need to edit your file again, click the pencil icon to edit (as shown bel
 Now, check what this looks like on your own page `https://raw.githack.com/YourUserName/YourUserName.github.io/YourBranchName/#!pages/vi/profiles/YourUserName.md`. The raw.githack link allows reviewers to preview your changes. Please double check that everything looks good and is working as you hoped before moving on to next section.
 
 **NOTE**:
-• If you don't see any changes in your page after editing your file then you need to clear your browser's cache or open your page in your browser's **"incognito"** or **"privacy"** mode. You can also press Ctrl+Shift+R or Ctrl+F5 to reload the page with cache cleared.
+• If you don't see any changes in your page after editing your file then you need to clear your browser's cache or open your page in your browser's **"incognito"** or **"privacy"** mode. You can also press Ctrl+Shift+R or Ctrl+F5 (on Mac Cmd+Shift+R) to reload the page with cache cleared.
 • As MDwiki site is what we use for "production," please **always check** if everything renders as you expected using raw.githack link. There are [different flavors of Markdown](https://github.com/commonmark/CommonMark/wiki/Markdown-Flavors). Use GitHub's preview tab for reference only.
 
 


### PR DESCRIPTION

Fixes #3073 

### Description
In the tips on how to reload a page with the cache cleared, the tips are only useful for non-Mac users. I added a small tip suggesting mac users to use a different set of keys to reload a web pages with cache cleared.

### Raw.Githack preview link
https://raw.githack.com/anastasia21112/anastasia21112.github.io/add-mac-keys-reload/#!pages/vi/vi-github-and-markdown.md

### Checklist 
[x]  Link works well
[x]  Able to automatically merge
[x]  Single line fix