### PR TITLE
Removed thusly from step 7 note (fixes #3079)

### DIFF
--- a/pages/vi/vi-nation.md
+++ b/pages/vi/vi-nation.md
@@ -15,7 +15,7 @@ There should be constant communication between the nation and the communities. W
 Make sure Vagrant is running and then click [here](http://localhost:3100) to access your Community Planet.
 It is recommended that you use Firefox since Planet is only guaranteed to run properly on Firefox.
 
-**NOTES**: After you register your community, but before you can sync with the nation, you need to create an additional dummy user in your community. Thusly, here is how to create a dummy user:
+**NOTES**: After you register your community, but before you can sync with the nation, you need to create an additional dummy user in your community. Here is how to create a dummy user:
 1. Create a quick additional user under "Become a Member" on the login page (HINT: When creating the dummy user, don't give it   a password that you actually use).
 2. Then, log in to your admin account and double-check that you're listed under Members on the Manager Settings page.
 3. Now that your community has a user, you can sync with the nation.


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our gitter chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #3079

### Description

Removed "thusly" from the Note under Step 7's introduction section. The word "thusly" is wrong, as it should just be "thus," but it is not needed anyway in the sentence.

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->

https://raw.githack.com/vinitnprabhu/vinitnprabhu.github.io/3079_remove_thusly/#!./pages/vi/vi-nation.md