### PR TITLE
Fix link in step 5 that directs to first steps (fixes #3234)

### DIFF
--- a/pages/mi/mi-github-and-repositories.md
+++ b/pages/mi/mi-github-and-repositories.md
@@ -207,4 +207,4 @@ If you would like to understand how syncing with the fork works, here is a usefu
 [Git help](https://git-scm.com/) - An encyclopedia of useful git workflows and terminology explanations.
 [Other helpful links and videos](mi-faq.md#Helpful_Links)
 
-#### Return to [First Steps](mi-first-steps.md)
+#### Return to [First Steps](mi-10-steps.md)

--- a/pages/mi/mi-github-and-repositories.md
+++ b/pages/mi/mi-github-and-repositories.md
@@ -207,4 +207,4 @@ If you would like to understand how syncing with the fork works, here is a usefu
 [Git help](https://git-scm.com/) - An encyclopedia of useful git workflows and terminology explanations.
 [Other helpful links and videos](mi-faq.md#Helpful_Links)
 
-#### Return to [First Steps](mi-10-steps.md)
+#### Return to [First Steps](mi-10-steps.md#Step_5_-_Git_Repositories:_A_Guide_to_Cloning,_Configuring,_and_Syncing_Forks)


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our discord chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #3234

### Description, Screenshots and/or Screencast 
Replaced the link at the bottom of Step 5 that takes you to First Steps
![image](https://github.com/open-learning-exchange/open-learning-exchange.github.io/assets/52076121/1ff504e6-1a92-4e48-ba6b-c483c2acf4e8)

### Raw.Githack preview link
https://raw.githack.com/rlam20/rlam20.github.io/edit-vi-first-steps-step-5/index.html#!./pages/mi/mi-github-and-repositories.md