### PR TITLE
Fix redundant links in step 3 (fixes #3242)

### DIFF
--- a/pages/mi/mi-github-and-repositories.md
+++ b/pages/mi/mi-github-and-repositories.md
@@ -207,4 +207,4 @@ If you would like to understand how syncing with the fork works, here is a usefu
 [Git help](https://git-scm.com/) - An encyclopedia of useful git workflows and terminology explanations.
 [Other helpful links and videos](mi-faq.md#Helpful_Links)
 
-#### Return to [First Steps](mi-first-steps.md)
+#### Return to [First Steps](mi-10-steps.md)

--- a/pages/mi/mi-myplanet-and-android-studio.md
+++ b/pages/mi/mi-myplanet-and-android-studio.md
@@ -39,6 +39,5 @@ After installing the app on your emulator or device, it will launch automaticall
 ## Useful Links
 
 - https://github.com/open-learning-exchange/myplanet?tab=readme-ov-file#getting-started-for-interns
-- https://github.com/open-learning-exchange/myplanet?tab=readme-ov-file#setting-up-the-android-device-for-development-and-testing
 
 #### Return to [First Steps](mi-10-steps.md#Step_3_-_Build_myPlanet_in_Android_Studio)


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our discord chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #3242

### Description, Screenshots and/or Screencast 
Removes a redundant link in step 3 that takes you to the same page as the first link in the 'Useful Links' section

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
https://raw.githack.com/rlam20/rlam20.github.io/edit-vi-first-steps-step-3/index.html#!./pages/mi/mi-myplanet-and-android-studio.md