### PR TITLE
Fix anchor links in step 1, 4, and 7 (fixes #3246)

### DIFF
--- a/pages/mi/mi-github-and-markdown.md
+++ b/pages/mi/mi-github-and-markdown.md
@@ -159,4 +159,4 @@ After your pull request has been **approved** and **merged** by us, you might wa
 
 [Other helpful links and videos](../vi/vi-faq.md#Helpful_Links)
 
-#### Return to [First Steps](mi-10-steps.md#Step_1_-_GitHub_&_Markdown_Setup)
+#### Return to [First Steps](mi-10-steps.md#Step_1_-_Markdown_&_Forking_Workflow)

--- a/pages/mi/mi-myplanet-course.md
+++ b/pages/mi/mi-myplanet-course.md
@@ -45,4 +45,4 @@ There are a few nations we
 - learning - android
 - guatemala - Spanish speaking
 
-#### Return to [First Steps](mi-10-steps.md)
+#### Return to [First Steps](mi-10-steps.md#Step_7_-_Take_a_Course_on_myPlanet,_Courses_Gardening)

--- a/pages/mi/mi-step4.md
+++ b/pages/mi/mi-step4.md
@@ -16,4 +16,4 @@ Take a screenshot of the myPlanet app's home page after logging in on your emula
 
 - [FAQ - What is the purpose of Nations and Communities, and how do they work together?](https://open-learning-exchange.github.io/#!pages/mi/mi-faq.md##Q11:_What_is_the_purpose_of_Nations_and_Communities,_and_how_do_they_work_together?)
 
-#### Return to [First Steps](mi-10-steps.md)
+#### Return to [First Steps](mi-10-steps.md#Step_4_-_Connect_myPlanet_app_to_Planet)


### PR DESCRIPTION
<!-- This is a new pull request template for open-learning-exchange.github.io.

Please make sure to:
- add (fixes #issue_number) to the end of pull request title when applicable,
- drop a link to your new pull request in our discord chat.

Thank you for contributing! -->

<!-- issue number this pull request resolves -->
Fixes #3246 

### Description, Screenshots and/or Screencast 
Edits the 'Return to First Steps' anchor links in steps 1, 4, and 7 to take you back to the step you were just on, keeping the page consistent with the rest of the step's anchor links.  

### Raw.Githack preview link
<!-- raw.githack link to page(s) changed -->
https://raw.githack.com/rlam20/rlam20.github.io/edit-first-steps-anchors/index.html#!./pages/mi/mi-10-steps.md#Step_1_-_Markdown_&_Forking_Workflow