### PR TITLE
use direct docker method in the docs

### DIFF
--- a/pages/mi/mi-faq.md
+++ b/pages/mi/mi-faq.md
@@ -235,7 +235,7 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 - [Docker Overview](https://docs.docker.com/engine/docker-overview/)
 - [Docker Compose](https://docs.docker.com/compose/overview/)
 - [Docker CLI Command](https://docs.docker.com/engine/reference/commandline/cli/)
-- [Docker Installation](http://open-learning-exchange.github.io/#!./pages/vi/vi-docker-installation.md)
+- [Docker Installation](https://docs.docker.com/install/)
 
 #### *GitHub and Markdown*
 

--- a/pages/vi/vi-configurations-docker.md
+++ b/pages/vi/vi-configurations-docker.md
@@ -1,0 +1,90 @@
+# Planet Configurations (Step 2.1)
+
+## Objectives
+
+* Learn about Planet and the difference between Nations and Communities
+* Use docker & docker compose to create a local production Planet Community
+* Register your Community and sync it with the Nation
+
+## Introduction
+
+The Planet is not only a library, but also an individualized learning system, where students can select their own books and courses to target their individual goals. The two kinds of Planet apps are described below.
+
+#### Planet Communities (Local)
+
+* Communities are how the Planet functions on a local network, with users connecting to a community using either a laptop or a Raspberry Pi and a router.
+* Periodically communities sync with Nations on the internet, which includes sending and receiving educational materials.
+* In step 1 you created a Planet community on your computer. As you follow the steps on this page, you will access and configure your community.
+
+#### Planet Nations (Internet)
+
+* Nations are Planet apps for the Internet, allowing communities to interact with each other.
+* Nations are connected to many communities and can run reports on any communities it owns.
+* As you complete these instructions, an OLE administrator will complete the registration of your community with the Virtual Intern Nation.
+
+## Running checks
+
+Please go to [http://localhost:3100](http://localhost:3100) or run `docker ps` in the command line to see if your community Planet is currently running(Should have 3 running containers). If not, please `cd` into `planet` directory in your local machine and run `docker compose -f planet.yml -p planet up -d`. Make sure to have the correct port number(3100), or else it will not work. 
+
+## Database
+[CouchDB](https://en.wikipedia.org/wiki/CouchDB) (also known as Apache CouchDB) is a database software that we use for the Planet. You can see the backend interface of our CouchDB at http://localhost:2300/_utils. In _utils, you have the opportunity to see all data of your Planet application.
+[PouchDB](https://pouchdb.com/learn.html) is an open-source JavaScript database inspired by Apache CouchDB that is designed to run well within the browser. This allows applications to save data locally, so that users can enjoy all the features of an app even when they're offline. This database is also used in the planet.
+
+## User Interface
+To see the actual user interface, go to http://localhost:3100.
+You will be shown the page below. Make sure you remember the credentials.
+
+![Become an Administrator](images/vi-become-admin.png)
+
+WARNING: Before you finish the registration, do not close your browser.
+You cannot go to the above registration form again.
+If you are in this situation, look at the ** [Second element of Troubleshooting in this page](#Troubleshooting)** 
+
+Next, fill out the configurations. Your name must be the same and should match your GitHub name so we can easily locate your community in Virtual Intern Nation. Pick **Virtual Intern Nation (vi)** for nation as in the example below. **After filling out your configurations, remember to save a screenshot of the configuration page so that you can post it on the [Discord server](https://discord.gg/mtgGD4EnYW) after submitting your registration request.**
+
+![Configurations](images/vi-configuration.png)
+
+**Note:** *To add images in the chat, just drag the image from your directory to the browser context and drop it in the messaging area or simply copy and paste the image.*
+
+Next, you will see a form that requires the contact details of the administrator (maintainer) of the community. Please provide your contact information.
+
+![Contact Details](images/vi-contact-details.png)
+
+Then, click on the **"Submit"** button. Your registration request for your community will be sent to the nation side for approval. You will see the following message.
+
+![Community Accepted into the Nation](images/vi-registration-accepted.png)
+
+Now you can login with the admin credential you created.
+
+Then, post to the [Discord server](https://discord.gg/mtgGD4EnYW) the screenshot you took earlier.
+
+## Troubleshooting
+
+1. When trying to access http://localhost:3100 for the first time you may experience and error where you do not get redirected to the configuration page and get a message such as "Error connecting to planet" when you try to login. A simple solution to this is to run `docker-compose -f planet.yml -p planet down -v` and then `docker-compose -f planet.yml -p planet up -d --build` to rebuild the containers.
+
+2. If you accidentally delete your Planet admin account, creating a new learner account on the login page will cause problems in later steps. The best way to solve this problem is to start over and create a new community. 
+Run
+```
+docker-compose -f planet.yml -p planet down -v
+docker-compose -f planet.yml -p planet up -d --build
+```
+in your planet folder. This destroys the containers & volumes and removes your community, allowing you start your community from scratch.
+
+3. In the case that you use have to destroy your community Planet, but the community registration still exists on the nation side. After rebuilding your community Planet, fill out the configurations again with a slightly different Name (e.g. adding a number or letter to the end of your original GitHub username) so that we can still locate your community on the Nation side. Also, remember to take a screenshot of the new configuration page and post it to the [Discord server](https://discord.gg/mtgGD4EnYW).
+
+4. There is a chance upon having your account approved that the website does not recognize you as registered. You will be stuck infinitely loading and upon refresh, the page will be blank. 
+
+  ![Not recognized](https://user-images.githubusercontent.com/22685147/58755806-bb6fe700-84b9-11e9-8a27-d3e3ab56ffba.png) 
+  
+  ![Blank](https://user-images.githubusercontent.com/22685147/58755807-be6ad780-84b9-11e9-86b5-c745f584ac41.png) 
+  
+  In order to fix this problem, simply follow the procedures stated above in step 2 and 3: use `docker-compose -f planet.yml -p planet down -v`, then `docker-compose -f planet.yml -p planet up -d --build`. Afterwards, use a slightly different name for your configuration, take a screenshot of the new configuration page, and post it to the [Discord server](https://discord.gg/mtgGD4EnYW).
+
+5. When you are trying to access http://localhost:3100 the page may not load at all, even if your account was configured correctly and fully approved. A first step would be to run in your planet folder `docker compose -f planet.yml -p planet down`. Then, you should proceed to clear the cookies from your browser. This step will be different for each browser. Finally, you should run `docker compose -f planet.yml -p planet up -d` to restart the containers before you reopen the browser to access the Planet again. **If this does not work, follow the previous steps above to rebuild your planet account.**
+
+## Next Section _([Step 3](vi-github-and-markdown.md))_ **→**
+
+Markdown is a lightweight markup language with plain text formatting syntax. In the next section, you will learn Markdown to create a profile page, and learn how to create a pull request.
+
+
+#### Return to [First Steps](vi-first-steps.md#Step_2_-_Planet_and_Docker)

--- a/pages/vi/vi-docker-tutorial.md
+++ b/pages/vi/vi-docker-tutorial.md
@@ -74,7 +74,7 @@ Below are the steps to run a production Planet Community with Docker:
 
 3. Download the compose file while in the `/srv/planet` directory
 
-  - `wget https://raw.githubusercontent.com/ole-vi/planet-prod-configs/main/planet-so.yml`
+  - `wget https://raw.githubusercontent.com/ole-vi/planet-prod-configs/main/planet-prod.yml`
   - `mv planet-so.yml planet.yml`
   
 4. Build and run the containers:
@@ -82,6 +82,16 @@ Below are the steps to run a production Planet Community with Docker:
   - `docker compose -f planet.yml -p planet up -d --build`
 
 
+The services will be running in the following ports:
+Planet: 3100
+ChatAPI: 5050
+CouchDB: 2300
+
+You can manually confirm by visiting each of the following URLs in your browser and getting the default messages & Planet app:
+
+- Planet: [http://localhost:3100](http://localhost:3100)
+- CouchDB: [http://localhost:2300](http://localhost:2300)
+- ChatAPI: [http://localhost:5050](http://localhost:5050)
     
 WARNING: If you run into any errors, check out our troubleshooting tips [Troubleshooting Configuration tips](vi-configurations-docker.md#Troubleshooting) 
     
@@ -287,7 +297,7 @@ Commands:
 [Docker Overview](https://docs.docker.com/engine/docker-overview/)
 [Docker Compose](https://docs.docker.com/compose/overview/)
 [Docker CLI Command](https://docs.docker.com/engine/reference/commandline/cli/)
-[Docker Installation](http://open-learning-exchange.github.io/#!./pages/vi/vi-docker-installation.md)
+[Docker Installation](https://docs.docker.com/install/)
 
 ## Next Section _([Step 2.2](vi-configurations-docker.md))_ **→**
 

--- a/pages/vi/vi-faq.md
+++ b/pages/vi/vi-faq.md
@@ -235,7 +235,7 @@ It can often be challenging to see the 'Big Picture', and it’s easy to lose si
 - [Docker Overview](https://docs.docker.com/engine/docker-overview/)
 - [Docker Compose](https://docs.docker.com/compose/overview/)
 - [Docker CLI Command](https://docs.docker.com/engine/reference/commandline/cli/)
-- [Docker Installation](http://open-learning-exchange.github.io/#!./pages/vi/vi-docker-installation.md)
+- [Docker Installation](https://docs.docker.com/install/)
 
 #### *GitHub and Markdown*
 

--- a/pages/vi/vi-first-steps.md
+++ b/pages/vi/vi-first-steps.md
@@ -6,17 +6,17 @@ Welcome to the first steps for becoming an OLE Virtual Intern! We treat these fi
 
 If you are selected for the internship after completing the steps, you will be officially invited to join the OLE interns team! We’ll add you to the Virtual Interns Discord server virtual intern channel and assign you to a specific team to work on developing and improving OLE’s software. Our current projects can be found [here](#!./pages/robots/rbts-intern-orientation.md#Familiarize_Yourself_with_Current_Projects_and_Issues).
 
-Once accepted, you and your team will work on an assignment, and we’ll switch up the assignments each week. As part of this internship, you will have the opportunity to work with software and languages including **[Git](https://git-scm.com/)**, **[GitHub](https://github.com/)**, **[Markdown](https://daringfireball.net/projects/markdown/)**, **[Vagrant](https://www.vagrantup.com/)**, **[VirtualBox](https://www.virtualbox.org/)**, **[Command Line/Terminal](https://www.w3schools.com/whatis/whatis_cli.asp)**, **[Command Line/Terminal Scripts](https://www.codecademy.com/articles/command-line-commands)**, **[Vim](https://www.vim.org/)**, **[CouchDB](http://couchdb.apache.org/)**, **[Docker](https://www.docker.com/)**, **[HTML5](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5)**, **[JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript)**, **[Node.js](https://nodejs.org/en/)**, **[Angular](https://angular.io/)**, **[Java](https://www.tutorialspoint.com/java/index.htm)**, and **[Kotlin](https://kotlinlang.org/)**.
+Once accepted, you and your team will work on an assignment, and we’ll switch up the assignments each week. As part of this internship, you will have the opportunity to work with software and languages including **[Git](https://git-scm.com/)**, **[GitHub](https://github.com/)**, **[Markdown](https://daringfireball.net/projects/markdown/)**, **[Command Line/Terminal](https://www.w3schools.com/whatis/whatis_cli.asp)**, **[Command Line/Terminal Scripts](https://www.codecademy.com/articles/command-line-commands)**, **[Vim](https://www.vim.org/)**, **[CouchDB](http://couchdb.apache.org/)**, **[Docker](https://www.docker.com/)**, **[HTML5](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5)**, **[JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript)**, **[Node.js](https://nodejs.org/en/)** and **[Angular](https://angular.io/)**.
 
 **NOTE**: This is an unpaid but intensive internship that requires 16 hours of work each week. More information about the internship can be found in our [FAQ](https://open-learning-exchange.github.io/#!pages/vi/vi-faq.md#General_Internship_Questions). If you have further questions, don’t hesitate to ask other members in the [Discord server](https://discord.gg/mtgGD4EnYW)!
 
 # The Steps
 
-Social coding is a huge part of any open source and collaborative project, and the Open Learning Exchange (OLE) is no different. In the following series of steps, you will learn about Markdown, Vagrant, Docker, Git, GitHub, GitHub issues, GitHub pull requests, etc. You will also be introduced to OLE’s digital library that hosts the learning materials – [Planet](https://github.com/open-learning-exchange/planet).
+Social coding is a huge part of any open source and collaborative project, and the Open Learning Exchange (OLE) is no different. In the following series of steps, you will learn about Markdown, Docker, Git, GitHub, GitHub issues, GitHub pull requests, etc. You will also be introduced to OLE’s digital library that hosts the learning materials – [Planet](https://github.com/open-learning-exchange/planet).
 
-Because these steps are simple, we expect high-quality work, which may take a longer time. We want to see that you are capable of using or learning how to use these tools (writing good GitHub issues, creating pull requests, navigating the Planet, using Vagrant and Docker, etc.). These steps may seem easy, but we want you to impress us with good GitHub etiquette and quality Markdown. The bare minimum would be to just passively follow the steps; you should do further reading about the tools/languages we use so you can further your understanding and relieve confusion if you're unclear about how something works. **Treat these steps as learning opportunities!** The GitHub and Markdown skills you practice here are very important for both this internship and a future software development career.
+Because these steps are simple, we expect high-quality work, which may take a longer time. We want to see that you are capable of using or learning how to use these tools (writing good GitHub issues, creating pull requests, navigating the Planet, using Docker, etc.). These steps may seem easy, but we want you to impress us with good GitHub etiquette and quality Markdown. The bare minimum would be to just passively follow the steps; you should do further reading about the tools/languages we use so you can further your understanding and relieve confusion if you're unclear about how something works. **Treat these steps as learning opportunities!** The GitHub and Markdown skills you practice here are very important for both this internship and a future software development career.
 
-The MDwiki has plenty of resources to help you complete the steps. There is a list of useful links at the end of each step. We also created a [FAQ page](https://open-learning-exchange.github.io/#!pages/vi/vi-faq.md) where you can find the answers to some commonly asked questions. This page has even more [useful links and video tutorials](https://open-learning-exchange.github.io/#!pages/vi/vi-faq.md#Helpful_Links) that will help you become familiar with the tools/languages we use. For anything that is not on the FAQ page, Google and Stack Exchange are your friends :)
+The MDwiki has plenty of resources to help you complete the steps. There is a list of useful links at the end of each step. We also created a [FAQ page](https://open-learning-exchange.github.io/#!pages/vi/vi-faq.md) where you can find the answers to some commonly asked questions. This page has even more [useful links and video tutorials](https://open-learning-exchange.github.io/#!pages/vi/vi-faq.md#Helpful_Links) that will help you become familiar with the tools/languages we use. For anything that is not on the FAQ page, Google, chatGPT and Stack Exchange are your friends :)
 
 **We also want you to keep us updated a relatively good amount in the Discord server as you complete these steps. We will ask you to send us messages, links, and screenshots along the First Steps, and we will use this to track your progress, so please do not forget to do so.** Check our [Discord Server](https://discord.gg/mtgGD4EnYW) page for more information about how to best communicate in Discord.
 
@@ -38,23 +38,25 @@ There are 3 sub-steps in this step:
 
 **NOTE**: See the [Planet User Manual](#!./pages/techgenius/tg-planet-user-manual.md) for an overview of functionality and an explanation of various terms. Your contributions will not only help us out but also give you a better understanding of what Planet does.
 
-## Step 1 - Planet and Vagrant
 
-There are 3 sub-steps in this step:
-
-
-1. [Planet Installation with Vagrant](#!./pages/vi/vi-planet-installation-vagrant.md)
-  The **Planet** is a virtual library that is deployed internationally to individuals in countries that typically do not have access to educational resources. In this step, you will learn about how to set up your own Community Planet using vagrant.
-
-2. [Planet Configurations](vi-configurations-vagrant.md)
-  In this step, you will learn about how to configure your Community Planet.
-
-3. [Vagrant Tutorial](vi-vagrant.md)
-  **Vagrant** is an open-source software product for building and maintaining portable virtual software development environments. In this step, you will learn about how to interact with Vagrant through the command-line interface.
+## Step 1 - Prerequisites
+  Setting up your local development environment is the first step in becoming a Virtual Intern. Follow the instructions on the [Prerequisites page](vi-prerequisites.md) to set up your local development environment. This step will guide you through setting up your local development environment with the necessary tools and software required for the internship.
+  This will enable you to successfully run both production and development planet versions
 
 ## Step 2 - Planet and Docker
 
-Follow the instructions on the [Docker Tutorial page](vi-docker-tutorial.md). **Docker** is a computer program that performs operating-system-level virtualization also known as containerization. In this step, you will learn the basics of interacting with Docker and Docker Compose through the command-line interface and basic commands for maintaining your Planet installation.
+There are 2 sub-steps in this step:
+
+1. [Docker Tutorial & Production Planet Installation](vi-docker-tutorial.md)
+  **Docker** is a computer program that performs operating-system-level virtualization also known as containerization. In this step, you will learn the basics of interacting with Docker and Docker Compose through the command-line interface and basic commands for maintaining your Planet installation. 
+  **Planet** is a Learning Management System(LMS) that is deployed internationally to individuals in countries that typically do not have access to educational resources. In this step, you will learn about how to set up your own Community Planet using Docker.
+
+2. [Planet Configurations](vi-configurations-docker.md)
+  In this step, you will learn about how to configure your Community Planet.
+
+<!-- 3. [Development Planet Installation](vi-planet-development-setup.md)
+   After setting up the local production environment in the previous step, you will now set up the development environment. Follow the instructions on the [Planet Development Setup page](vi-planet-development-setup.md). Here you interact with docker, git, angular, node.js and the planet application to set up the development environment.
+   You will be required to run a new community planet configuration with a slightly different name(github username + dev) and take a screenshot of the new configuration page and post it to the [Discord server](https://discord.gg/mtgGD4EnYW). -->
 
 ## Step 3 - Markdown and Fork Tutorial
 

--- a/pages/vi/vi-planet-installation-prerequisites.md
+++ b/pages/vi/vi-planet-installation-prerequisites.md
@@ -1,0 +1,85 @@
+# Planet Installation (Step 1)
+
+## Objectives
+
+- Set up an environment for Planet
+
+## Introduction
+
+The Planet is a virtual library that is deployed internationally to individuals in countries that typically do not have access to educational resources.
+
+Please follow the directions of your OS below to install your community Planet and its dependencies on our system.
+
+## Prerequisites
+
+#### Staying Organized
+
+We recommend you designate a new directory for your work at OLE. This puts all of your OLE related repositories in one place and enables you to be organized and efficient.
+
+To do this, you could make a new folder directly through your OS GUI. Or you could open `Terminal`(macOS or Ubuntu), `cmd`(Windows) and use the following commands: (Note the commands should be identical on all three operating systems)
+
+```bash
+cd Desktop
+mkdir OLE
+cd OLE
+```
+
+#### Storage Space
+
+Before proceeding with the installation, it is necessary to have at least a couple of GBs of free space on your computer.
+
+* To check your current storage space on **Mac** go to the Apple Logo on the top left of your screen, `About This mac > Storage`
+* To check your current storage space on **Windows** go to `Settings > System > Storage`
+
+---
+
+## Steps for Your OS
+The required dependencies are Git, Docker, Docker compose, Node(14), NPM(6), Angular CLI(10). For the planet production setup only you will need Git, Docker and Docker Compose.
+
+### OS Notes
+
+#### For Windows
+
+#### For macOS
+We assume that [brew](http://brew.sh/) is already installed:
+
+#### For Ubuntu
+We assume you have updated your package lists and upgraded your installed packages.
+
+```
+sudo apt-get update && sudo apt-get upgrade -y
+```
+
+
+- **Git**
+[Git](https://git-scm.com) is an open source version control system that we use for communication and management for our software. More specifically, we use discord.com for communication and github.com for software management. [Download](https://git-scm.com/download/win)
+
+- **Docker**
+[Docker](https://www.docker.com) is a platform for developers and sysadmins to develop, deploy, and run applications with containers. The use of containers to deploy applications is called containerization. Containers are not new, but their use for easily deploying applications is. [Download](https://docs.docker.com/engine/install/)
+
+**Note**: For ubuntu we recommend using the Docker Engine and not the Docker Desktop.
+
+
+- **Node.js v14 & NPM v6**
+[Node.js](https://nodejs.org) is an open-source, cross-platform, back-end JavaScript runtime environment that runs on the V8 engine and executes JavaScript code outside a web browser. [Download](https://nodejs.org/en/download/package-manager)
+
+On linux and macOS, use `nvm`
+
+- **Angular CLI v10**
+[Angular CLI](https://cli.angular.io) is a command-line interface for Angular. [Install](https://cli.angular.io)
+
+```
+npm install -g @angular/cli@10
+```
+
+---
+
+
+## Next Section ([Step 2.1](vi-docker-tutorial.md)) **→**
+
+Now  you have installed the required dependencies for Planet. Next, you will learn how to use Docker and Docker Compose to create a local production Planet Community.
+
+#### Return to [First Steps](vi-first-steps.md#Step_1_-_Prerequisites)
+
+
+


### PR DESCRIPTION
Migrate from vagrant to direct docker method

- Add the prerequisites installation
- Docker & Planet setup guide: local production system only
- Hide vagrant mentions