### PR TITLE
fix link to first-steps in mi-issues-and-prs.md (fixes #3517)

### DIFF
--- a/pages/mi/mi-issues-and-prs.md
+++ b/pages/mi/mi-issues-and-prs.md
@@ -30,4 +30,4 @@ Once you complete Step 8 you will have:
 
 **HINT**: You can track your progress with the number of pull requests and issues [here](../track-first-steps-progress.md).
 
-#### Return to [First Steps](mi-first-steps.md#Step_8_-_Create_More_Issues_and_Pull_Requests)
+#### Return to [First Steps](mi-10-steps.md#Step_8_-_Create_More_Issues_and_Pull_Requests)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.*

### Before Creating the Pull Request

- [x] Verify the changes are on a new branch other than `master` – it should say "compare: branch-name".
- [x] Start the pull request title with lowercase letters, e.g., `add githubusername.md`.
- [x] Add issue number to the end of the pull request title when applicable, e.g., `update mi-faq.md (fixes #3264)`.

### After Creating the Pull Request

- [x] Go to "Commits" tab, make sure the commit username is clickable and linked to your GitHub account correctly.
- [x] Review the "Files changed" tab to ensure there are no unnecessary files or changes included in the pull request.
- [x] Verify that the raw.githack preview link is included in the description.
  - [x] Preview the MDwiki rendered changes using the raw.githack link. Ensure it displays as expected without any errors.
- [x] Drop a link to this pull request in our discord channel.

### Description, Screenshots and/or Screencast
<!-- Include a brief description of the changes along with any relevant screenshots or screencasts when necessary. Also, mention the issue number this pull request resolves. -->
The "Return to First Steps" link in mi-issues-and-prs.md is not pointing to the desired location. I have fixed it so that it now takes users back to the Step 8 section in the first step page. Now the link takes users back to the following screen.

<img width="1623" alt="Screenshot 2024-12-17 at 11 08 08 AM" src="https://github.com/user-attachments/assets/99dde178-cf1a-4d70-b067-3520f44a2610" />


fixes #3517 


### Raw.Githack Preview Link
<!-- Provide the raw.githack link to the page(s) changed. Example: https://raw.githack.com/nhk057/nhk057.github.io/add-nhk057-profile/index.html#!pages/mi/profiles/nhk057.md -->
https://raw.githack.com/pavi38/pavi38.github.io/3517-issues-prs-dead-link/index.html#!./pages/mi/mi-issues-and-prs.md
