### PR TITLE
update mi-10-steps.md (fixes #3747)

### DIFF
--- a/pages/mi/mi-10-steps.md
+++ b/pages/mi/mi-10-steps.md
@@ -87,9 +87,7 @@ Follow the guide at [Create More Issues and Pull Requests](mi-issues-and-prs.md)
 
 ## Step 9 - Kotlin Tour
 
-myPlanet uses Kotlin as the development language. If you have no or little prior exposure to Kotlin, please go over the [Kotlin crash-course](https://developer.android.com/kotlin/learn) on Android Developers to gain some familiarity.
-
-Additionally, you may also go over the official [Kotlin tour](https://kotlinlang.org/docs/kotlin-tour-welcome.html). Optionally, there are practice exercise at the end of each topic for you to get some hands on exercise.
+myPlanet uses Kotlin as the development language. If you have no or little prior exposure to Kotlin, please go over the official [Kotlin tour](https://kotlinlang.org/docs/kotlin-tour-welcome.html). Optionally, there are practice exercises at the end of each topic for you to get some hands on experience.
 
 We also recommend checking out the [Kotlin docs](https://kotlinlang.org/docs/home.html).
 


### PR DESCRIPTION
### Before Creating the Pull Request

- [x] Verify the changes are on a new branch other than `master` – it says "compare: remove-kotlin-reference-3747".
- [x] Start the pull request title with lowercase letters.
- [x] Add issue number to the end of the pull request title: `(fixes #3747)`.

### After Creating the Pull Request

- [x] Go to "Commits" tab and confirm the commit username is clickable and correctly linked to my GitHub account.
- [x] Review the "Files changed" tab to ensure there are no unnecessary files included.
- [x] Verify that the raw.githack preview link is included in the description.
  - [x] Preview the MDwiki rendered changes using the raw.githack link and confirmed it displays correctly without errors.
- [x] Drop a link to this pull request in the Discord channel.

---

### Description, Screenshots and/or Screencast

This pull request removes an unnecessary Kotlin reference from the Mobile Intern First Steps (mi-10-steps.md) documentation to improve clarity and reduce irrelevant content.

The removed reference was not directly related to the objectives of the guide and could potentially confuse new interns.

fixes #3747

---

### Raw.Githack Preview Link

https://raw.githack.com/UmutDiler0/UmutDiler0.github.io/remove-kotlin-reference-3747/index.html#!pages/mi/mi-10-steps.md
